### PR TITLE
fix bug and improved code for export

### DIFF
--- a/stack/rest/src/test/java/org/apache/usergrid/rest/management/ExportResourceIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/management/ExportResourceIT.java
@@ -18,21 +18,18 @@
 package org.apache.usergrid.rest.management;
 
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.ws.rs.core.MediaType;
-
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import org.apache.usergrid.cassandra.Concurrent;
+import org.apache.usergrid.rest.AbstractRestIT;
 import org.codehaus.jackson.JsonNode;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.usergrid.cassandra.Concurrent;
-import org.apache.usergrid.rest.AbstractRestIT;
-
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
+import javax.ws.rs.core.MediaType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.apache.usergrid.utils.MapUtils.hashMap;
 import static org.junit.Assert.assertEquals;
@@ -276,16 +273,6 @@ public class ExportResourceIT extends AbstractRestIT {
         ClientResponse.Status responseStatus = ClientResponse.Status.OK;
 
         HashMap<String, Object> payload = new HashMap<String, Object>();
-        Map<String, Object> properties = new HashMap<String, Object>();
-        Map<String, Object> storage_info = new HashMap<String, Object>();
-        //TODO: always put dummy values here and ignore this test.
-        //TODO: add a ret for when s3 values are invalid.
-        storage_info.put( "bucket_location", "insert bucket name here" );
-
-
-        properties.put( "storage_provider", "s3" );
-        properties.put( "storage_info", storage_info );
-
 
         try {
             node = resource().path( "/management/orgs/test-organization/apps/test-app/export" )
@@ -305,16 +292,6 @@ public class ExportResourceIT extends AbstractRestIT {
         ClientResponse.Status responseStatus = ClientResponse.Status.OK;
 
         HashMap<String, Object> payload = new HashMap<String, Object>();
-        Map<String, Object> properties = new HashMap<String, Object>();
-        Map<String, Object> storage_info = new HashMap<String, Object>();
-        //TODO: always put dummy values here and ignore this test.
-        //TODO: add a ret for when s3 values are invalid.
-        storage_info.put( "bucket_location", "insert bucket name here" );
-
-
-        properties.put( "storage_provider", "s3" );
-        properties.put( "storage_info", storage_info );
-
 
         try {
             node = resource().path( "/management/orgs/test-organization/export" )
@@ -335,16 +312,6 @@ public class ExportResourceIT extends AbstractRestIT {
         ClientResponse.Status responseStatus = ClientResponse.Status.OK;
 
         HashMap<String, Object> payload = new HashMap<String, Object>();
-        Map<String, Object> properties = new HashMap<String, Object>();
-        Map<String, Object> storage_info = new HashMap<String, Object>();
-        //TODO: always put dummy values here and ignore this test.
-        //TODO: add a ret for when s3 values are invalid.
-        storage_info.put( "bucket_location", "insert bucket name here" );
-
-
-        properties.put( "storage_provider", "s3" );
-        properties.put( "storage_info", storage_info );
-
 
         try {
             node = resource().path( "/management/orgs/test-organization/apps/test-app/collection/users/export" )
@@ -358,8 +325,6 @@ public class ExportResourceIT extends AbstractRestIT {
     }
 
 
-    //
-    //
     @Test
     public void exportGetCollectionUnauthorized() throws Exception {
         JsonNode node = null;
@@ -377,7 +342,6 @@ public class ExportResourceIT extends AbstractRestIT {
     }
 
 
-    //
     @Test
     public void exportGetApplicationUnauthorized() throws Exception {
         JsonNode node = null;
@@ -433,7 +397,6 @@ public class ExportResourceIT extends AbstractRestIT {
         assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
     }
 
-
     @Test
     public void exportPostApplicationNullPointerStorageInfo() throws Exception {
         JsonNode node = null;
@@ -454,7 +417,6 @@ public class ExportResourceIT extends AbstractRestIT {
         }
         assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
     }
-
 
     @Test
     public void exportPostCollectionNullPointerStorageInfo() throws Exception {
@@ -477,6 +439,27 @@ public class ExportResourceIT extends AbstractRestIT {
         assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
     }
 
+    @Test
+    public void exportPostOrganizationNullPointerStorageProvider() throws Exception {
+        JsonNode node = null;
+        ClientResponse.Status responseStatus = ClientResponse.Status.OK;
+
+        HashMap<String, Object> payload = payloadBuilder();
+        HashMap<String, Object> properties = ( HashMap<String, Object> ) payload.get( "properties" );
+        //remove storage_info field
+        properties.remove( "storage_provider" );
+
+
+        try {
+            node = resource().path( "/management/orgs/test-organization/export" )
+                    .queryParam( "access_token", superAdminToken() ).accept( MediaType.APPLICATION_JSON )
+                    .type( MediaType.APPLICATION_JSON_TYPE ).post( JsonNode.class, payload );
+        }
+        catch ( UniformInterfaceException uie ) {
+            responseStatus = uie.getResponse().getClientResponseStatus();
+        }
+        assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
+    }
 
     @Test
     public void exportPostApplicationNullPointerStorageProvider() throws Exception {
@@ -500,7 +483,6 @@ public class ExportResourceIT extends AbstractRestIT {
         assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
     }
 
-
     @Test
     public void exportPostCollectionNullPointerStorageProvider() throws Exception {
         JsonNode node = null;
@@ -523,6 +505,59 @@ public class ExportResourceIT extends AbstractRestIT {
         assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
     }
 
+    @Test
+    public void exportPostOrganizationNullPointerStorageVerification() throws Exception {
+        JsonNode node = null;
+        ClientResponse.Status responseStatus = ClientResponse.Status.OK;
+
+        HashMap<String, Object> payload = payloadBuilder();
+        HashMap<String, Object> properties = ( HashMap<String, Object> ) payload.get( "properties" );
+        HashMap<String, Object> storage_info = ( HashMap<String, Object> ) properties.get( "storage_info" );
+        //remove storage_key field
+        storage_info.remove( "s3_key" );
+
+        try {
+            node = resource().path( "/management/orgs/test-organization/export" )
+                    .queryParam( "access_token", superAdminToken() ).accept( MediaType.APPLICATION_JSON )
+                    .type( MediaType.APPLICATION_JSON_TYPE ).post( JsonNode.class, payload );
+        }
+        catch ( UniformInterfaceException uie ) {
+            responseStatus = uie.getResponse().getClientResponseStatus();
+        }
+        assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
+
+        payload = payloadBuilder();
+        properties = ( HashMap<String, Object> ) payload.get( "properties" );
+        storage_info = ( HashMap<String, Object> ) properties.get( "storage_info" );
+        //remove storage_key field
+        storage_info.remove( "s3_access_id" );
+
+        try {
+            node = resource().path( "/management/orgs/test-organization/export" )
+                    .queryParam( "access_token", superAdminToken() ).accept( MediaType.APPLICATION_JSON )
+                    .type( MediaType.APPLICATION_JSON_TYPE ).post( JsonNode.class, payload );
+        }
+        catch ( UniformInterfaceException uie ) {
+            responseStatus = uie.getResponse().getClientResponseStatus();
+        }
+        assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
+
+        payload = payloadBuilder();
+        properties = ( HashMap<String, Object> ) payload.get( "properties" );
+        storage_info = ( HashMap<String, Object> ) properties.get( "storage_info" );
+        //remove storage_key field
+        storage_info.remove( "bucket_location" );
+
+        try {
+            node = resource().path( "/management/orgs/test-organization/export" )
+                    .queryParam( "access_token", superAdminToken() ).accept( MediaType.APPLICATION_JSON )
+                    .type( MediaType.APPLICATION_JSON_TYPE ).post( JsonNode.class, payload );
+        }
+        catch ( UniformInterfaceException uie ) {
+            responseStatus = uie.getResponse().getClientResponseStatus();
+        }
+        assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
+    }
 
     @Test
     public void exportPostApplicationNullPointerStorageVerification() throws Exception {
@@ -577,7 +612,6 @@ public class ExportResourceIT extends AbstractRestIT {
         }
         assertEquals( ClientResponse.Status.BAD_REQUEST, responseStatus );
     }
-
 
     @Test
     public void exportPostCollectionNullPointerStorageVerification() throws Exception {

--- a/stack/services/src/main/java/org/apache/usergrid/management/export/ExportServiceImpl.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/export/ExportServiceImpl.java
@@ -425,6 +425,11 @@ public class ExportServiceImpl implements ExportService {
     private void saveCollectionMembers( JsonGenerator jg, EntityManager em, String collection, Entity entity )
             throws Exception {
 
+        // Write connections
+        saveConnections( entity, em, jg );
+        // Write dictionaries
+        saveDictionaries( entity, em, jg );
+
         Set<String> collections = em.getCollections( entity );
 
         // If your application doesn't have any e


### PR DESCRIPTION
"Fix Bug"
- USERGRID-193
- https://issues.apache.org/jira/browse/USERGRID-193
- The saveConnections() and saveDictionaries() methods are called at the end of SaveCollectionMembers() in file ExportServiceImpl.java, but if collection for an entity was null, then it would just return and not export the connections and dictionaries for that particular entity, thus calling these functions in the start of the method ensures, that all connections and dictionaries are always exported.

"Improve Export Test Cases"
- USERGRID-194
- https://issues.apache.org/jira/browse/USERGRID-194
- Removed redundant code and added testcases for exportOrganization Null pointer checks.

Conflicts:
    stack/services/src/main/java/org/apache/usergrid/management/export/ExportServiceImpl.java
