### PR TITLE
Maven  3.2/3.1 build fix

### DIFF
--- a/stack/rest/pom.xml
+++ b/stack/rest/pom.xml
@@ -353,25 +353,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.3.1</version>
-        <executions>
-          <execution>
-            <id>install jar</id>
-            <phase>install</phase>
-            <goals>
-              <goal>install-file</goal>
-            </goals>
-            <configuration>
-              <packaging>jar</packaging>
-              <artifactId>${project.artifactId}</artifactId>
-              <groupId>${project.groupId}</groupId>
-              <version>${project.version}</version>
-              <file>
-                ${project.build.directory}/${project.artifactId}-${project.version}.jar
-              </file>
-            </configuration>
-          </execution>
-        </executions>
+        <version>2.5.1</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Fixes issues with building the stack with Maven versions greater than 3.0.5
