### PR TITLE
Fix USERGRID-225 by allowing ${blah} expressions in paths.

### DIFF
--- a/portal/config.js
+++ b/portal/config.js
@@ -52,7 +52,7 @@ Usergrid.regex = {
   roleNameRegex: new RegExp("^([0-9a-zA-Z./-]{3,25})+$"),
   emailRegex: new RegExp("^(([0-9a-zA-Z]+[_\+.-]?)+@[0-9a-zA-Z]+[0-9,a-z,A-Z,.,-]*(.){1}[a-zA-Z]{2,4})+$"),
   passwordRegex: /(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/,
-  pathRegex: new RegExp("^/[a-zA-Z0-9\.\*_~-]+(\/[a-zA-Z0-9\.\*_~-]+)*$"),
+  pathRegex: new RegExp("^/[a-zA-Z0-9\.\*_\$\{\}~-]+(\/[a-zA-Z0-9\.\*_\$\{\}~-]+)*$"),
   titleRegex: new RegExp("[a-zA-Z0-9.!-?]+[\/]?"),
   urlRegex: new RegExp("^(http?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$"),
   zipRegex: new RegExp("^[0-9]{5}(?:-[0-9]{4})?$"),


### PR DESCRIPTION
This new regex allows paths to be specified like so:

```
/users/${user}/**
```

See also: https://issues.apache.org/jira/browse/USERGRID-225
