### PR TITLE
URL getter & setter for local Usergrid installation.

### DIFF
--- a/sdks/php/lib/vendor/Apache/Usergrid/Client.php
+++ b/sdks/php/lib/vendor/Apache/Usergrid/Client.php
@@ -46,13 +46,13 @@ class Client {
   private $url = 'http://api.usergrid.com';
 
   /**
-   * Organization name. Find your in the Admin Portal 
+   * Organization name. Find your in the Admin Portal
    * @var string
    */
   private $org_name;
 
   /**
-   * App name. Find your in the Admin Portal 
+   * App name. Find your in the Admin Portal
    * @var string
    */
   private $app_name;
@@ -777,6 +777,35 @@ class Client {
     return $notification;
   }
 
+    /**
+     * Gets URL of Usergrid endpoint
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Sets Usergrid endpoint URL
+     *
+     * @param string $url
+     * @return bool
+     * @throws UGException
+     */
+    public function setUrl($url)
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
+            $this->url = $url;
+            return true;
+        }
+        else {
+            if ($this->use_exceptions) {
+                throw new UGException('Invalid URL');
+            }
+        }
+    }
 
 }
 


### PR DESCRIPTION
We are preparing to launch Usergrid on own infrastructure thus we followed those steps: [Deploying to local Tomcat & Cassandra](http://usergrid.readthedocs.org/en/latest/deploy-local.html)

We are planning to use Usergrid on web & mobile. Since on web we use PHP, I had no way to alter `\Apache\Usergrid\Client::$url` value. I created two simple methods:
- `\Apache\Usergrid\Client::getUrl` (just a getter)
- `\Apache\Usergrid\Client::setUrl` (setter using `filter_var()` to validate URL; throwing `UGException()` exception on failure).
