### PR TITLE
Specify config for username/password.

### DIFF
--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -111,6 +111,10 @@ Here's a complete example properties file to get you started.
 
     # The cassandra host to use
     cassandra.url=localhost:9160
+
+    # if your cassandra instance requires username/password
+    cassandra.username=someuser
+    cassandra.password=somepassword
     
     # The strategy to use when creating the keyspace. This is the default. 
     # We recommend creating the keyspace with this default, then editing it 


### PR DESCRIPTION
This is a minor doc fix - turns out you can specify username/password, it was just not clear how.
