### PR TITLE
Portal: Use same host and port for override url (default)

### DIFF
--- a/portal/config.js
+++ b/portal/config.js
@@ -22,9 +22,19 @@ var Usergrid = Usergrid || {};
 
 Usergrid.showNotifcations = true;
 
+/* Single tomcat (all-in-one) installations. 
+   Try and use the same hostname and port for the APIURL - Assumes that Portal and Usergrid
+   are deployed on the same tomcat instance
+*/
+var urlNPort = location.protocol+'//'+location.hostname+(location.port ? ':'+location.port: '') + "/";
 
-// used only if hostname does not match a real server name
-Usergrid.overrideUrl = 'http://localhost:8080/';
+if(urlNPort.indexOf("http") != -1) {
+    Usergrid.overrideUrl = urlNPort
+}
+else {
+    // used only if hostname does not match a real server name
+    Usergrid.overrideUrl = 'http://localhost:8080/';
+}
 
 Usergrid.options = {
   client:{


### PR DESCRIPTION
Try and use the same hostname and port for the API overrideUrl. Assumes that Portal and Usergrid are deployed on the same tomcat instance. For example, this would be useful when a single Tomcat instance is being used to host both portal and usergrid apps.