### PR TITLE
Remove cassandra keyspace name app index naming.  The use…

### DIFF
--- a/stack/awscluster/src/main/groovy/configure_usergrid.groovy
+++ b/stack/awscluster/src/main/groovy/configure_usergrid.groovy
@@ -100,6 +100,9 @@ cassandra.cluster=${clusterName}
 cassandra.keyspace.strategy=org.apache.cassandra.locator.NetworkTopologyStrategy
 cassandra.keyspace.replication=${cassEc2Region}:${replFactor}
 
+# This property is required to be set and cannot be left to the default.
+usergrid.cluster_name=usergrid
+
 cassandra.timeout=5000
 cassandra.connections=${tomcatThreads}
 hystrix.threadpool.graph_user.coreSize=${hystrixThreads}

--- a/stack/config/src/main/resources/usergrid-default.properties
+++ b/stack/config/src/main/resources/usergrid-default.properties
@@ -577,9 +577,10 @@ usergrid.counter.batch.interval=30
 #
 usergrid.version.build=${version}
 
-# Set a unique cluster name that this Usergrid instance is a member of.
+# Set a unique cluster name that this Usergrid instance is a member of.  This MUST be set to something
+# other than 'default-property', otherwise startup will fail.
 #
-#usergrid.cluster_name=ug
+#usergrid.cluster_name=default-property
 
 
 

--- a/stack/config/src/test/resources/usergrid-test.properties
+++ b/stack/config/src/test/resources/usergrid-test.properties
@@ -26,6 +26,10 @@
 # instead.
 #
 
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid
+
 # Whether to user the remote Cassandra cluster or not
 cassandra.use_remote=false
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/asyncevents/AmazonAsyncEventService.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/asyncevents/AmazonAsyncEventService.java
@@ -80,7 +80,7 @@ public class AmazonAsyncEventService implements AsyncEventService {
 
     // SQS maximum receive messages is 10
     private static final int MAX_TAKE = 10;
-    public static final String QUEUE_NAME = "es_queue";
+    public static final String QUEUE_NAME = "es"; //keep this short as AWS limits queue name size to 80 chars
 
     private final QueueManager queue;
     private final QueueScope queueScope;
@@ -122,7 +122,7 @@ public class AmazonAsyncEventService implements AsyncEventService {
         this.eventBuilder = eventBuilder;
         this.rxTaskScheduler = rxTaskScheduler;
 
-        this.queueScope = new QueueScopeImpl(QUEUE_NAME, QueueScope.RegionImplementation.ALLREGIONS);
+        this.queueScope = new QueueScopeImpl(QUEUE_NAME, QueueScope.RegionImplementation.ALL);
         this.queue = queueManagerFactory.getQueueManager(queueScope);
         this.indexProcessorFig = indexProcessorFig;
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/asyncevents/AmazonAsyncEventService.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/asyncevents/AmazonAsyncEventService.java
@@ -80,7 +80,7 @@ public class AmazonAsyncEventService implements AsyncEventService {
 
     // SQS maximum receive messages is 10
     private static final int MAX_TAKE = 10;
-    public static final String QUEUE_NAME = "es"; //keep this short as AWS limits queue name size to 80 chars
+    public static final String QUEUE_NAME = "index"; //keep this short as AWS limits queue name size to 80 chars
 
     private final QueueManager queue;
     private final QueueScope queueScope;

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ApplicationIndexLocationStrategy.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ApplicationIndexLocationStrategy.java
@@ -25,7 +25,6 @@ import org.apache.usergrid.persistence.core.scope.ApplicationScope;
 import org.apache.usergrid.persistence.index.IndexAlias;
 import org.apache.usergrid.persistence.index.IndexFig;
 import org.apache.usergrid.persistence.index.IndexLocationStrategy;
-import org.apache.usergrid.utils.StringUtils;
 
 /**
  * Strategy for getting the application index name.

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ApplicationIndexLocationStrategy.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ApplicationIndexLocationStrategy.java
@@ -44,7 +44,7 @@ class ApplicationIndexLocationStrategy implements IndexLocationStrategy {
                                             final ApplicationIndexBucketLocator applicationIndexBucketLocator){
         this.indexFig = indexFig;
         this.applicationScope = applicationScope;
-        this.indexRootName  = clusterFig.getClusterName() + "_" + cassandraFig.getApplicationKeyspace().toLowerCase();
+        this.indexRootName  = clusterFig.getClusterName().toLowerCase();
         this.indexBucketName = indexRootName + "_applications_" + applicationIndexBucketLocator.getBucket(applicationScope);
         this.alias =  new ApplicationIndexAlias(indexFig, applicationScope, indexRootName);
     }

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ManagementIndexLocationStrategy.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ManagementIndexLocationStrategy.java
@@ -23,12 +23,9 @@ import org.apache.usergrid.corepersistence.util.CpNamingUtils;
 import org.apache.usergrid.persistence.core.astyanax.CassandraFig;
 import org.apache.usergrid.persistence.core.guicyfig.ClusterFig;
 import org.apache.usergrid.persistence.core.scope.ApplicationScope;
-import org.apache.usergrid.persistence.core.scope.ApplicationScopeImpl;
 import org.apache.usergrid.persistence.index.IndexAlias;
 import org.apache.usergrid.persistence.index.IndexFig;
 import org.apache.usergrid.persistence.index.IndexLocationStrategy;
-import org.apache.usergrid.persistence.model.entity.Id;
-import org.apache.usergrid.utils.StringUtils;
 
 /**
  * Strategy for getting the management index name
@@ -48,8 +45,10 @@ class ManagementIndexLocationStrategy implements IndexLocationStrategy {
         this.indexFig = indexFig;
         this.coreIndexFig = coreIndexFig;
         this.applicationScope = CpNamingUtils.getApplicationScope( CpNamingUtils.getManagementApplicationId().getUuid());
-        //remove usergrid
-        this.indexName = clusterFig.getClusterName().toLowerCase() + "_" + coreIndexFig.getManagementAppIndexName().toLowerCase();  ////use lowercase value
+        //use lowercase values
+        this.indexName = clusterFig.getClusterName().toLowerCase() + "_" +
+                         cassandraFig.getApplicationKeyspace().toLowerCase() + "_" +
+                         coreIndexFig.getManagementAppIndexName().toLowerCase();
         this.alias = new ManagementIndexAlias(indexFig,indexName);
     }
     @Override

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ManagementIndexLocationStrategy.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ManagementIndexLocationStrategy.java
@@ -49,7 +49,7 @@ class ManagementIndexLocationStrategy implements IndexLocationStrategy {
         this.coreIndexFig = coreIndexFig;
         this.applicationScope = CpNamingUtils.getApplicationScope( CpNamingUtils.getManagementApplicationId().getUuid());
         //remove usergrid
-        this.indexName = clusterFig.getClusterName() + "_" + cassandraFig .getApplicationKeyspace().toLowerCase() + "_" + coreIndexFig.getManagementAppIndexName().toLowerCase();  ////use lowercase value
+        this.indexName = clusterFig.getClusterName().toLowerCase() + "_" + coreIndexFig.getManagementAppIndexName().toLowerCase();  ////use lowercase value
         this.alias = new ManagementIndexAlias(indexFig,indexName);
     }
     @Override

--- a/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/IndexNamingTest.java
+++ b/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/IndexNamingTest.java
@@ -74,12 +74,10 @@ public class IndexNamingTest {
     private ApplicationScope managementApplicationScope;
     private ApplicationIndexLocationStrategy applicationLocationStrategy;
     private ManagementIndexLocationStrategy managementLocationStrategy;
-    private String keyspacename;
     private String clusterName;
 
     @Before
     public void setup(){
-        keyspacename = cassandraFig.getApplicationKeyspace().toLowerCase();
         clusterName = clusterFig.getClusterName();
         this.applicationScope = CpNamingUtils.getApplicationScope(UUID.randomUUID());
         this.managementApplicationScope = CpNamingUtils.getApplicationScope(CpNamingUtils.getManagementApplicationId().getUuid());
@@ -93,10 +91,10 @@ public class IndexNamingTest {
         //check that factory works
         assertEquals(indexLocationStrategy.getIndexRootName(),managementLocationStrategy.getIndexRootName());
         //check that root name is as expected
-        assertEquals(indexLocationStrategy.getIndexRootName(),clusterName + "_" + keyspacename + "_" + indexProcessorFig.getManagementAppIndexName());
+        assertEquals(indexLocationStrategy.getIndexRootName(),clusterName + "_" + indexProcessorFig.getManagementAppIndexName());
         //check bucket name is as expected
         assertEquals(indexLocationStrategy.getIndexRootName(), indexLocationStrategy.getIndexInitialName());
-        assertEquals(indexLocationStrategy.getIndexInitialName(),clusterName + "_" + keyspacename + "_" +indexProcessorFig.getManagementAppIndexName());
+        assertEquals(indexLocationStrategy.getIndexInitialName(),clusterName + "_" +indexProcessorFig.getManagementAppIndexName());
 
     }
 
@@ -107,11 +105,11 @@ public class IndexNamingTest {
         String managementAppIndexName = indexProcessorFig.getManagementAppIndexName();
         assertEquals(
             indexLocationStrategy.getAlias().getReadAlias(),
-            clusterName + "_" + keyspacename+ "_" + managementAppIndexName + "_read_" + indexFig.getAliasPostfix()
+            clusterName + "_" + managementAppIndexName + "_read_" + indexFig.getAliasPostfix()
         );
         assertEquals(
             indexLocationStrategy.getAlias().getWriteAlias(),
-            clusterName + "_" + keyspacename + "_" + managementAppIndexName + "_write_" + indexFig.getAliasPostfix()
+            clusterName + "_" + managementAppIndexName + "_write_" + indexFig.getAliasPostfix()
         );
     }
 
@@ -126,7 +124,7 @@ public class IndexNamingTest {
 
         assertEquals(
             indexLocationStrategy.getIndexRootName(),
-            clusterName + "_" + keyspacename
+            clusterName
         );
 
     }
@@ -137,11 +135,11 @@ public class IndexNamingTest {
         String applicationId = applicationScope.getApplication().getUuid().toString().toLowerCase();
         assertEquals(
             indexLocationStrategy.getAlias().getReadAlias(),
-            clusterName + "_" + keyspacename+"_"+ applicationId + "_read_" + indexFig.getAliasPostfix()
+            clusterName +"_"+ applicationId + "_read_" + indexFig.getAliasPostfix()
         );
         assertEquals(
             indexLocationStrategy.getAlias().getWriteAlias(),
-            clusterName + "_" + keyspacename+"_"+ applicationId + "_write_" + indexFig.getAliasPostfix()
+            clusterName +"_"+ applicationId + "_write_" + indexFig.getAliasPostfix()
         );
     }
 
@@ -156,7 +154,7 @@ public class IndexNamingTest {
                 );
             names.add(indexLocationStrategyBucket.getIndexInitialName());
         }
-        Pattern regex = Pattern.compile(clusterName+"_"+keyspacename+"_applications_\\d+");
+        Pattern regex = Pattern.compile(clusterName+"_applications_\\d+");
         //always hashes to same bucket
         assertTrue(names.size() == 1);
         names = new HashSet<>();

--- a/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/IndexNamingTest.java
+++ b/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/IndexNamingTest.java
@@ -20,7 +20,6 @@
 package org.apache.usergrid.corepersistence.index;
 
 import com.google.inject.Inject;
-import junit.framework.Assert;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.usergrid.corepersistence.TestIndexModule;
 import org.apache.usergrid.corepersistence.util.CpNamingUtils;
@@ -74,11 +73,13 @@ public class IndexNamingTest {
     private ApplicationScope managementApplicationScope;
     private ApplicationIndexLocationStrategy applicationLocationStrategy;
     private ManagementIndexLocationStrategy managementLocationStrategy;
+    private String keyspaceName;
     private String clusterName;
 
     @Before
     public void setup(){
-        clusterName = clusterFig.getClusterName();
+        keyspaceName = cassandraFig.getApplicationKeyspace().toLowerCase();
+        clusterName = clusterFig.getClusterName().toLowerCase();
         this.applicationScope = CpNamingUtils.getApplicationScope(UUID.randomUUID());
         this.managementApplicationScope = CpNamingUtils.getApplicationScope(CpNamingUtils.getManagementApplicationId().getUuid());
         this.managementLocationStrategy = new ManagementIndexLocationStrategy(clusterFig,cassandraFig,indexFig, indexProcessorFig);
@@ -91,10 +92,10 @@ public class IndexNamingTest {
         //check that factory works
         assertEquals(indexLocationStrategy.getIndexRootName(),managementLocationStrategy.getIndexRootName());
         //check that root name is as expected
-        assertEquals(indexLocationStrategy.getIndexRootName(),clusterName + "_" + indexProcessorFig.getManagementAppIndexName());
+        assertEquals(indexLocationStrategy.getIndexRootName(),clusterName + "_" + keyspaceName + "_" + indexProcessorFig.getManagementAppIndexName());
         //check bucket name is as expected
         assertEquals(indexLocationStrategy.getIndexRootName(), indexLocationStrategy.getIndexInitialName());
-        assertEquals(indexLocationStrategy.getIndexInitialName(),clusterName + "_" +indexProcessorFig.getManagementAppIndexName());
+        assertEquals(indexLocationStrategy.getIndexInitialName(),clusterName + "_" + keyspaceName + "_" +indexProcessorFig.getManagementAppIndexName());
 
     }
 
@@ -105,11 +106,11 @@ public class IndexNamingTest {
         String managementAppIndexName = indexProcessorFig.getManagementAppIndexName();
         assertEquals(
             indexLocationStrategy.getAlias().getReadAlias(),
-            clusterName + "_" + managementAppIndexName + "_read_" + indexFig.getAliasPostfix()
+            clusterName + "_" + keyspaceName + "_" + managementAppIndexName + "_read_" + indexFig.getAliasPostfix()
         );
         assertEquals(
             indexLocationStrategy.getAlias().getWriteAlias(),
-            clusterName + "_" + managementAppIndexName + "_write_" + indexFig.getAliasPostfix()
+            clusterName + "_" + keyspaceName + "_" + managementAppIndexName + "_write_" + indexFig.getAliasPostfix()
         );
     }
 

--- a/stack/core/src/test/resources/usergrid-custom-test.properties
+++ b/stack/core/src/test/resources/usergrid-custom-test.properties
@@ -29,4 +29,6 @@ elasticsearch.queue_impl.resolution=true
 
 elasticsearch.buffer_timeout=1
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid
 

--- a/stack/core/src/test/resources/usergrid-scheduler-test.properties
+++ b/stack/core/src/test/resources/usergrid-scheduler-test.properties
@@ -22,3 +22,5 @@ usergrid.scheduler.job.maxfail=2
 
 elasticsearch.buffer_timeout=1
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/collection/src/test/resources/dynamic-test.properties
+++ b/stack/corepersistence/collection/src/test/resources/dynamic-test.properties
@@ -8,3 +8,6 @@ cassandra.cluster_name=Usergrid
 collections.keyspace=Usergrid_Collections
 cassandra.timeout=5000
 collection.stage.transient.timeout=5
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/collection/src/test/resources/usergrid-CHOP.properties
+++ b/stack/corepersistence/collection/src/test/resources/usergrid-CHOP.properties
@@ -10,3 +10,6 @@ cassandra.hosts=${chop.cassandra.hosts}
 cassandra.cluster_name=Usergrid
 collections.keyspace=Usergrid_Collections
 cassandra.timeout=5000
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/collection/src/test/resources/usergrid-UNIT.properties
+++ b/stack/corepersistence/collection/src/test/resources/usergrid-UNIT.properties
@@ -13,3 +13,6 @@ collections.keyspace.strategy.options=replication_factor:1
 collections.keyspace.strategy.class=SimpleStrategy
 
 collection.stage.transient.timeout=5
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/collection/src/test/resources/usergrid.properties
+++ b/stack/corepersistence/collection/src/test/resources/usergrid.properties
@@ -1,1 +1,2 @@
-# No properties in our test env
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/guice/CommonModule.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/guice/CommonModule.java
@@ -96,7 +96,9 @@ public class CommonModule extends AbstractModule {
          */
 
         install(new GuicyFigModule(RxSchedulerFig.class));
+
         install(new GuicyFigModule(ClusterFig.class));
+        bind(SettingsValidationCluster.class).asEagerSingleton(); //validate props from ClusterFig on startup
 
         bind(RxTaskScheduler.class).to(RxTaskSchedulerImpl.class);
     }

--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/guice/SettingsValidationCluster.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/guice/SettingsValidationCluster.java
@@ -1,0 +1,26 @@
+package org.apache.usergrid.persistence.core.guice;
+
+
+import org.apache.usergrid.persistence.core.guicyfig.ClusterFig;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Created by russo on 8/27/15.
+ */
+@Singleton
+public class SettingsValidationCluster {
+
+    @Inject
+    public SettingsValidationCluster(final ClusterFig clusterFig) {
+
+        final String configuredClusterName = clusterFig.getClusterName();
+        final String defaultCluster = ClusterFig.VALIDATION_DEFAULT_VALUE;
+
+        Preconditions.checkArgument(!configuredClusterName.equalsIgnoreCase(defaultCluster), ClusterFig.CLUSTER_NAME_PROPERTY + " property must be set.");
+
+    }
+
+}

--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/guicyfig/ClusterFig.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/guicyfig/ClusterFig.java
@@ -30,8 +30,18 @@ import org.safehaus.guicyfig.Key;
 @FigSingleton
 public interface ClusterFig extends GuicyFig{
 
-    @Default( "ug" )
-    @Key( "usergrid.cluster_name" ) //"usergrid.cluster_name"
+
+    /**
+     * This value used in guice module validations so we can force a value to be set.  See IndexSettingValidation
+     * for an example use.
+     */
+    String VALIDATION_DEFAULT_VALUE = "default-property";
+
+    String CLUSTER_NAME_PROPERTY = "usergrid.cluster_name";
+
+
+    @Default( VALIDATION_DEFAULT_VALUE )
+    @Key( CLUSTER_NAME_PROPERTY )
     String getClusterName();
 
 }

--- a/stack/corepersistence/common/src/test/java/org/apache/usergrid/persistence/core/guice/SettingsValidationClusterTest.java
+++ b/stack/corepersistence/common/src/test/java/org/apache/usergrid/persistence/core/guice/SettingsValidationClusterTest.java
@@ -1,0 +1,39 @@
+package org.apache.usergrid.persistence.core.guice;
+
+import org.apache.usergrid.persistence.core.guicyfig.ClusterFig;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by russo on 8/27/15.
+ */
+public class SettingsValidationClusterTest {
+
+    @Test
+    public void clusterValidationSuccess(){
+
+        final String myCluster = "myCluster";
+
+        ClusterFig clusterFig = mock(ClusterFig.class);
+        when(clusterFig.getClusterName()).thenReturn(myCluster);
+
+
+        new SettingsValidationCluster(clusterFig);
+
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void clusterValidationFailure(){
+
+        final String myPrefix = ClusterFig.VALIDATION_DEFAULT_VALUE;
+
+        ClusterFig clusterFig = mock(ClusterFig.class);
+        when(clusterFig.getClusterName()).thenReturn(myPrefix);
+
+        new SettingsValidationCluster(clusterFig);
+
+    }
+
+}

--- a/stack/corepersistence/common/src/test/resources/usergrid-UNIT.properties
+++ b/stack/corepersistence/common/src/test/resources/usergrid-UNIT.properties
@@ -12,3 +12,6 @@ collections.keyspace.strategy.options=replication_factor:1
 collections.keyspace.strategy.class=SimpleStrategy
 
 collection.stage.transient.timeout=5
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/common/src/test/resources/usergrid.properties
+++ b/stack/corepersistence/common/src/test/resources/usergrid.properties
@@ -1,1 +1,2 @@
-# No properties in our test env
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/graph/src/test/resources/usergrid-AWS.properties
+++ b/stack/corepersistence/graph/src/test/resources/usergrid-AWS.properties
@@ -19,3 +19,5 @@ collection.stage.transient.timeout=60
 hystrix.threadpool.graph_user.coreSize=9
 hystrix.threadpool.graph_async.coreSize=9
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/graph/src/test/resources/usergrid-CHOP.properties
+++ b/stack/corepersistence/graph/src/test/resources/usergrid-CHOP.properties
@@ -10,3 +10,6 @@ cassandra.hosts=${chop.cassandra.hosts}
 cassandra.cluster_name=Usergrid
 collections.keyspace=Usergrid_Collections
 cassandra.timeout=5000
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/graph/src/test/resources/usergrid-SHARD.properties
+++ b/stack/corepersistence/graph/src/test/resources/usergrid-SHARD.properties
@@ -21,3 +21,6 @@
 
 # Keep nothing but overriding test defaults in here
 usergrid.graph.shard.size=10000
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/graph/src/test/resources/usergrid-UNIT.properties
+++ b/stack/corepersistence/graph/src/test/resources/usergrid-UNIT.properties
@@ -17,3 +17,6 @@ usergrid.graph.shard.repair.chance=.20
 
 hystrix.threadpool.graph_user.coreSize=8
 hystrix.threadpool.graph_async.coreSize=8
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/graph/src/test/resources/usergrid.properties
+++ b/stack/corepersistence/graph/src/test/resources/usergrid.properties
@@ -1,1 +1,2 @@
-# No properties in our test env
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/queryindex/src/test/resources/dynamic-test.properties
+++ b/stack/corepersistence/queryindex/src/test/resources/dynamic-test.properties
@@ -14,3 +14,5 @@ elasticsearch.startup=external
 elasticsearch.force-refresh=false
 
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/queryindex/src/test/resources/usergrid-CHOP.properties
+++ b/stack/corepersistence/queryindex/src/test/resources/usergrid-CHOP.properties
@@ -15,3 +15,6 @@ index.query.limit.default=10
 elasticsearch.indexname=usergrid
 elasticsearch.embedded=false
 elasticsearch.force_refresh=false
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/queryindex/src/test/resources/usergrid-UNIT.properties
+++ b/stack/corepersistence/queryindex/src/test/resources/usergrid-UNIT.properties
@@ -33,3 +33,5 @@ elasticsearch.cursor_timeout.minutes=10
 
 elasticsearch.buffer_timeout=1
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/queryindex/src/test/resources/usergrid.properties
+++ b/stack/corepersistence/queryindex/src/test/resources/usergrid.properties
@@ -1,1 +1,2 @@
-# No properties in our test env
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/QueueScope.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/QueueScope.java
@@ -24,12 +24,12 @@ import org.apache.usergrid.persistence.core.scope.ApplicationScope;
 public interface QueueScope  {
 
     /**
-     * LOCALREGION will create a SNS topic with a queue subscription in a single AWS region.
-     * ALLREGIONS will create SNS topics and queue subscriptions  in ALL AWS regions.
+     * LOCAL will create a SNS topic with a queue subscription in a single AWS region.
+     * ALL will create SNS topics and queue subscriptions  in ALL AWS regions.
      */
     enum RegionImplementation {
-        LOCALREGION,
-        ALLREGIONS
+        LOCAL,
+        ALL
     }
 
     /**

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/SNSQueueManagerImpl.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/SNSQueueManagerImpl.java
@@ -161,7 +161,7 @@ public class SNSQueueManagerImpl implements QueueManager {
             logger.error(String.format("Unable to subscribe PRIMARY queue=[%s] to topic=[%s]", queueUrl, primaryTopicArn), e);
         }
 
-        if (fig.isMultiRegion() && scope.getRegionImplementation() == QueueScope.RegionImplementation.ALLREGIONS) {
+        if (fig.isMultiRegion() && scope.getRegionImplementation() == QueueScope.RegionImplementation.ALL) {
 
             String multiRegion = fig.getRegionList();
 

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/SNSQueueManagerImpl.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/SNSQueueManagerImpl.java
@@ -36,6 +36,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import org.apache.usergrid.persistence.core.astyanax.CassandraFig;
 import org.apache.usergrid.persistence.core.guicyfig.ClusterFig;
 import org.apache.usergrid.persistence.queue.*;
 import org.apache.usergrid.persistence.queue.Queue;
@@ -54,6 +55,7 @@ public class SNSQueueManagerImpl implements QueueManager {
     private final QueueScope scope;
     private final QueueFig fig;
     private final ClusterFig clusterFig;
+    private final CassandraFig cassandraFig;
     private final AmazonSQSClient sqs;
     private final AmazonSNSClient sns;
     private final AmazonSNSAsyncClient snsAsync;
@@ -105,10 +107,11 @@ public class SNSQueueManagerImpl implements QueueManager {
 
 
     @Inject
-    public SNSQueueManagerImpl(@Assisted QueueScope scope, QueueFig fig, ClusterFig clusterFig) {
+    public SNSQueueManagerImpl(@Assisted QueueScope scope, QueueFig fig, ClusterFig clusterFig, CassandraFig cassandraFig) {
         this.scope = scope;
         this.fig = fig;
         this.clusterFig = clusterFig;
+        this.cassandraFig = cassandraFig;
 
         try {
             sqs = createSQSClient(getRegion());
@@ -299,8 +302,8 @@ public class SNSQueueManagerImpl implements QueueManager {
 
 
     private String getName() {
-        String name = clusterFig.getClusterName() + "_" + scope.getName() + "_" + scope.getRegionImplementation();
-
+        String name = clusterFig.getClusterName() + "_" + cassandraFig.getApplicationKeyspace() + "_" + scope.getName() + "_" + scope.getRegionImplementation();
+        name = name.toLowerCase(); //user lower case values
         Preconditions.checkArgument(name.length() <= 80, "Your name must be < than 80 characters");
 
         return name;

--- a/stack/corepersistence/queue/src/test/java/org/apache/usergrid/persistence/queue/QueueManagerTest.java
+++ b/stack/corepersistence/queue/src/test/java/org/apache/usergrid/persistence/queue/QueueManagerTest.java
@@ -66,7 +66,7 @@ public class QueueManagerTest {
 
     @Before
     public void mockApp() {
-        this.scope = new QueueScopeImpl( "testQueue", QueueScope.RegionImplementation.LOCALREGION );
+        this.scope = new QueueScopeImpl( "testQueue", QueueScope.RegionImplementation.LOCAL);
         qm = qmf.getQueueManager(scope);
     }
 

--- a/stack/launcher/src/main/resources/usergrid-standalone.properties
+++ b/stack/launcher/src/main/resources/usergrid-standalone.properties
@@ -35,6 +35,9 @@
 # instead.
 #
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid
+
 # Whether to user the remote Cassandra cluster or not
 cassandra.use_remote=false
 

--- a/stack/query-validator/src/test/resources/usergrid-custom-test.properties
+++ b/stack/query-validator/src/test/resources/usergrid-custom-test.properties
@@ -27,3 +27,6 @@ usergrid.sysadmin.login.name=superuser
 usergrid.sysadmin.login.email=superuser@usergrid.com
 usergrid.sysadmin.login.password=superpassword
 usergrid.sysadmin.login.allowed=true
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/rest/src/test/resources/corepersistence-UNIT.properties
+++ b/stack/rest/src/test/resources/corepersistence-UNIT.properties
@@ -17,3 +17,6 @@
 # Overrides
 
 usergrid.notifications.listener.run=false
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/rest/src/test/resources/usergrid-custom-test.properties
+++ b/stack/rest/src/test/resources/usergrid-custom-test.properties
@@ -46,3 +46,6 @@ usergrid.use.default.queue=true
 
 elasticsearch.managment_index=usergrid_rest_management
 #cassandra.keyspace.application=rest_tests_schema
+
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid

--- a/stack/services/src/main/java/org/apache/usergrid/services/notifications/ApplicationQueueManager.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/notifications/ApplicationQueueManager.java
@@ -36,7 +36,7 @@ public interface ApplicationQueueManager {
 
     public static final String NOTIFIER_ID_POSTFIX = ".notifier.id";
 
-    public static final  String DEFAULT_QUEUE_NAME = "push_v1";
+    public static final  String DEFAULT_QUEUE_NAME = "push"; //keep this short as AWS limits queue name size to 80 chars
 
     /**
      * send notification to queue

--- a/stack/services/src/main/java/org/apache/usergrid/services/notifications/NotificationsService.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/notifications/NotificationsService.java
@@ -19,7 +19,6 @@ package org.apache.usergrid.services.notifications;
 
 import java.util.*;
 
-import org.apache.usergrid.persistence.queue.DefaultQueueManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,10 +26,8 @@ import org.apache.usergrid.mq.Message;
 import org.apache.usergrid.persistence.Entity;
 import org.apache.usergrid.persistence.EntityManagerFactory;
 import org.apache.usergrid.persistence.EntityRef;
-import org.apache.usergrid.persistence.PathQuery;
 import org.apache.usergrid.persistence.SimpleEntityRef;
 import org.apache.usergrid.persistence.core.metrics.MetricsFactory;
-import org.apache.usergrid.persistence.entities.Device;
 import org.apache.usergrid.persistence.entities.Notification;
 import org.apache.usergrid.persistence.entities.Notifier;
 import org.apache.usergrid.persistence.entities.Receipt;
@@ -104,7 +101,7 @@ public class NotificationsService extends AbstractCollectionService {
         postTimer = metricsService.getTimer(this.getClass(), "collection.post_requests");
         JobScheduler jobScheduler = new JobScheduler(sm,em);
         String name = ApplicationQueueManagerImpl.getQueueNames( props );
-        QueueScope queueScope = new QueueScopeImpl( name, QueueScope.RegionImplementation.LOCALREGION );
+        QueueScope queueScope = new QueueScopeImpl( name, QueueScope.RegionImplementation.LOCAL);
         queueManagerFactory = getApplicationContext().getBean( Injector.class ).getInstance(QueueManagerFactory.class);
         QueueManager queueManager = queueManagerFactory.getQueueManager(queueScope);
         notificationQueueManager = new ApplicationQueueManagerImpl(jobScheduler,em,queueManager,metricsService,props);

--- a/stack/services/src/main/java/org/apache/usergrid/services/notifications/QueueListener.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/notifications/QueueListener.java
@@ -21,8 +21,6 @@ import com.codahale.metrics.Timer;
 import com.google.common.cache.*;
 import com.google.inject.Injector;
 
-import org.apache.usergrid.corepersistence.CpSetup;
-
 import org.apache.usergrid.persistence.EntityManager;
 import org.apache.usergrid.persistence.EntityManagerFactory;
 
@@ -36,7 +34,7 @@ import org.apache.usergrid.services.notifications.impl.ApplicationQueueManagerIm
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
-import javax.annotation.PostConstruct;
+
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -146,7 +144,7 @@ public class QueueListener  {
         com.codahale.metrics.Timer timer = metricsService.getTimer(QueueListener.class, "execute.dequeue");
         svcMgr = smf.getServiceManager(smf.getManagementAppId());
         LOG.info("getting from queue {} ", queueName);
-        QueueScope queueScope = new QueueScopeImpl( queueName, QueueScope.RegionImplementation.LOCALREGION );
+        QueueScope queueScope = new QueueScopeImpl( queueName, QueueScope.RegionImplementation.LOCAL);
         QueueManager queueManager = TEST_QUEUE_MANAGER != null ? TEST_QUEUE_MANAGER : queueManagerFactory.getQueueManager(queueScope);
         // run until there are no more active jobs
         final AtomicLong runCount = new AtomicLong(0);

--- a/stack/services/src/main/java/org/apache/usergrid/services/queues/QueueListener.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/queues/QueueListener.java
@@ -160,7 +160,7 @@ public abstract class QueueListener  {
         LOG.info("QueueListener: Starting execute process.");
         svcMgr = smf.getServiceManager(smf.getManagementAppId());
         LOG.info("getting from queue {} ", queueName);
-        QueueScope queueScope = new QueueScopeImpl( queueName, QueueScope.RegionImplementation.LOCALREGION);
+        QueueScope queueScope = new QueueScopeImpl( queueName, QueueScope.RegionImplementation.LOCAL);
         QueueManager queueManager = TEST_QUEUE_MANAGER != null ? TEST_QUEUE_MANAGER : queueManagerFactory.getQueueManager(queueScope);
         // run until there are no more active jobs
         long runCount = 0;

--- a/stack/services/src/test/resources/usergrid-custom-test.properties
+++ b/stack/services/src/test/resources/usergrid-custom-test.properties
@@ -38,3 +38,5 @@ elasticsearch.queue_impl.resolution=true
 usergrid.use.default.queue=true
 
 
+# This property is required to be set and cannot be defaulted anywhere
+usergrid.cluster_name=usergrid


### PR DESCRIPTION
…rgrid cluster name is now also required.  The AWS queues will also now include the keyspace name to support the mgmt app events which are dependent on the keyspace being used.

For anyone running Usergrid from two-dot-o-dev branch currently, setting the ````usergrid.cluster_name```` property and a system re-index is required.