### PR TITLE
USERGRID-918: add query parameter to limit checks for connections

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ServiceResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ServiceResource.java
@@ -266,13 +266,35 @@ public class ServiceResource extends AbstractContextResource {
         logger.debug( "ServiceResource.executeServiceRequest" );
 
         boolean tree = "true".equalsIgnoreCase( ui.getQueryParameters().getFirst( "tree" ) );
+
+        String connectionQueryParm = ui.getQueryParameters().getFirst("connections");
+        boolean returnInboundConnections = true;
+        boolean returnOutboundConnections = true;
+
+        // connection info can be blocked only for GETs
+        if (action == ServiceAction.GET) {
+           if ("none".equalsIgnoreCase(connectionQueryParm)) {
+               returnInboundConnections = false;
+               returnOutboundConnections = false;
+           } else if ("in".equalsIgnoreCase(connectionQueryParm)) {
+               returnOutboundConnections = false;
+           } else if ("out".equalsIgnoreCase(connectionQueryParm)) {
+               returnInboundConnections = false;
+           } else if (! "all".equalsIgnoreCase(connectionQueryParm)) {
+               // unrecognized variable
+               if (connectionQueryParm != null)
+                   logger.error( String.format( "Invalid connection query parameter=%s, ignoring.", connectionQueryParm));
+           }
+        }
+
         boolean collectionGet = false;
         if ( action == ServiceAction.GET ) {
             collectionGet = (getServiceParameters().size() == 1 && InflectionUtils
                     .isPlural(getServiceParameters().get(0)));
         }
         addQueryParams( getServiceParameters(), ui );
-        ServiceRequest r = services.newRequest( action, tree, getServiceParameters(), payload );
+        ServiceRequest r = services.newRequest( action, tree, getServiceParameters(), payload,
+            returnInboundConnections, returnOutboundConnections );
         response.setServiceRequest( r );
         ServiceResults results = r.execute();
         if ( results != null ) {

--- a/stack/services/src/main/java/org/apache/usergrid/services/AbstractService.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/AbstractService.java
@@ -384,22 +384,26 @@ public abstract class AbstractService implements Service {
                 metadata.putAll(defaultEntityMetadata);
             }
 
-            Set<Object> connections = getConnectedTypesSet(entity);
-            if (connections != null) {
-                Map<String, Object> m = new LinkedHashMap<String, Object>();
-                for (Object n : connections) {
-                    m.put(n.toString(), path + "/" + n);
+            if (request.isReturnsOutboundConnections()) {
+                Set<Object> connections = getConnectedTypesSet(entity);
+                if (connections != null) {
+                    Map<String, Object> m = new LinkedHashMap<String, Object>();
+                    for (Object n : connections) {
+                        m.put(n.toString(), path + "/" + n);
+                    }
+                    metadata.put("connections", m);
                 }
-                metadata.put("connections", m);
             }
 
-            Set<Object> connecting = getConnectingTypesSet(entity);
-            if (connecting != null) {
-                Map<String, Object> m = new LinkedHashMap<String, Object>();
-                for (Object n : connecting) {
-                    m.put(n.toString(), path + "/connecting/" + n);
+            if (request.isReturnsInboundConnections()) {
+                Set<Object> connecting = getConnectingTypesSet(entity);
+                if (connecting != null) {
+                    Map<String, Object> m = new LinkedHashMap<String, Object>();
+                    for (Object n : connecting) {
+                        m.put(n.toString(), path + "/connecting/" + n);
+                    }
+                    metadata.put("connecting", m);
                 }
-                metadata.put("connecting", m);
             }
 
             Set<String> collections = getCollectionSet(entity);

--- a/stack/services/src/main/java/org/apache/usergrid/services/ServiceManager.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/ServiceManager.java
@@ -342,13 +342,13 @@ public class ServiceManager {
 
 
     public ServiceRequest newRequest( ServiceAction action, List<ServiceParameter> parameters ) throws Exception {
-        return newRequest( action, false, parameters, null );
+        return newRequest( action, false, parameters, null, true, true );
     }
 
 
     public ServiceRequest newRequest( ServiceAction action, List<ServiceParameter> parameters, ServicePayload payload )
             throws Exception {
-        return newRequest( action, false, parameters, payload );
+        return newRequest( action, false, parameters, payload, true, true );
     }
 
 
@@ -366,7 +366,8 @@ public class ServiceManager {
 
 
     public ServiceRequest newRequest( ServiceAction action, boolean returnsTree, List<ServiceParameter> parameters,
-                                      ServicePayload payload ) throws Exception {
+                                      ServicePayload payload, boolean returnsInboundConnections,
+                                      boolean returnsOutboundConnections ) throws Exception {
 
         if ( em != null ) {
             if ( action != null ) {
@@ -396,9 +397,14 @@ public class ServiceManager {
         }
 
         String serviceName = pluralize( ServiceParameter.dequeueParameter( parameters ).getName() );
-        return new ServiceRequest( this, action, serviceName, parameters, payload, returnsTree );
+        return new ServiceRequest( this, action, serviceName, parameters, payload, returnsTree,
+            returnsInboundConnections, returnsOutboundConnections );
     }
 
+    public ServiceRequest newRequest( ServiceAction action, boolean returnsTree, List<ServiceParameter> parameters,
+                                      ServicePayload payload ) throws Exception {
+        return newRequest( action, returnsTree, parameters, payload, true, true );
+    }
 
     public void notifyExecutionEventListeners( ServiceAction action, ServiceRequest request, ServiceResults results,
                                                ServicePayload payload ) {

--- a/stack/services/src/main/java/org/apache/usergrid/services/ServiceRequest.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/ServiceRequest.java
@@ -55,6 +55,8 @@ public class ServiceRequest {
     private final List<ServiceParameter> parameters;
     private final String childPath;
     private final boolean returnsTree;
+    private final boolean returnsInboundConnections;
+    private final boolean returnsOutboundConnections;
     private final ServicePayload payload;
     private final List<ServiceParameter> originalParameters;
 
@@ -62,7 +64,8 @@ public class ServiceRequest {
 
 
     public ServiceRequest( ServiceManager services, ServiceAction action, String serviceName,
-                           List<ServiceParameter> parameters, ServicePayload payload, boolean returnsTree ) {
+                           List<ServiceParameter> parameters, ServicePayload payload, boolean returnsTree,
+                           boolean returnsInboundConnections, boolean returnsOutboundConnections ) {
         this.services = services;
         this.action = action;
         parent = null;
@@ -73,6 +76,8 @@ public class ServiceRequest {
         this.parameters = parameters;
         this.originalParameters = Collections.unmodifiableList( new ArrayList<ServiceParameter>( parameters ) );
         this.returnsTree = returnsTree;
+        this.returnsInboundConnections = returnsInboundConnections;
+        this.returnsOutboundConnections = returnsOutboundConnections;
         if ( payload == null ) {
             payload = new ServicePayload();
         }
@@ -80,19 +85,26 @@ public class ServiceRequest {
         this.payload = payload;
     }
 
+    public ServiceRequest( ServiceManager services, ServiceAction action, String serviceName,
+                           List<ServiceParameter> parameters, ServicePayload payload, boolean returnsTree) {
+        this( services, action, serviceName, parameters, payload, returnsTree, true, true);
+    }
+
 
     public ServiceRequest( ServiceManager services, ServiceAction action, String serviceName,
                            List<ServiceParameter> parameters, ServicePayload payload ) {
-        this( services, action, serviceName, parameters, payload, false );
+        this( services, action, serviceName, parameters, payload, false, true, true );
     }
 
 
     public ServiceRequest( ServiceRequest parent, EntityRef owner, String path, String childPath, String serviceName,
                            List<ServiceParameter> parameters ) {
-        services = parent.services;
-        returnsTree = parent.returnsTree;
-        action = parent.action;
-        payload = parent.payload;
+        this.services = parent.services;
+        this.returnsTree = parent.returnsTree;
+        this.returnsInboundConnections = parent.returnsInboundConnections;
+        this.returnsOutboundConnections = parent.returnsOutboundConnections;
+        this.action = parent.action;
+        this.payload = parent.payload;
         this.parent = parent;
         this.owner = owner;
         this.serviceName = serviceName;
@@ -108,7 +120,8 @@ public class ServiceRequest {
 
     public ServiceRequest( ServiceManager services, ServiceAction action, ServiceRequest parent, EntityRef owner,
                            String path, String childPath, String serviceName, List<ServiceParameter> parameters,
-                           ServicePayload payload, boolean returnsTree ) {
+                           ServicePayload payload, boolean returnsTree, boolean returnsInboundConnections,
+                           boolean returnsOutboundConnections ) {
         this.services = services;
         this.action = action;
         this.parent = parent;
@@ -119,19 +132,27 @@ public class ServiceRequest {
         this.originalParameters = Collections.unmodifiableList( new ArrayList<ServiceParameter>( parameters ) );
         this.childPath = childPath;
         this.returnsTree = returnsTree;
+        this.returnsInboundConnections = returnsInboundConnections;
+        this.returnsOutboundConnections = returnsOutboundConnections;
         this.payload = payload;
+    }
+
+    public ServiceRequest( ServiceManager services, ServiceAction action, ServiceRequest parent, EntityRef owner,
+                           String path, String childPath, String serviceName, List<ServiceParameter> parameters,
+                           ServicePayload payload, boolean returnsTree ) {
+        this(services, action, parent, owner, path, childPath, serviceName, parameters, payload, returnsTree, true, true);
     }
 
 
     public static ServiceRequest withPath( ServiceRequest r, String path ) {
         return new ServiceRequest( r.services, r.action, r.parent, r.owner, path, r.childPath, r.serviceName,
-                r.parameters, r.payload, r.returnsTree );
+                r.parameters, r.payload, r.returnsTree, r.returnsInboundConnections, r.returnsOutboundConnections );
     }
 
 
     public static ServiceRequest withChildPath( ServiceRequest r, String childPath ) {
         return new ServiceRequest( r.services, r.action, r.parent, r.owner, r.path, childPath, r.serviceName,
-                r.parameters, r.payload, r.returnsTree );
+                r.parameters, r.payload, r.returnsTree, r.returnsInboundConnections, r.returnsOutboundConnections );
     }
 
 
@@ -140,9 +161,7 @@ public class ServiceRequest {
     }
 
 
-    public ServiceRequest withChildPath( String childPath ) {
-        return withChildPath( this, childPath );
-    }
+    public ServiceRequest withChildPath( String childPath ) { return withChildPath( this, childPath ); }
 
 
     public long getId() {
@@ -355,10 +374,11 @@ public class ServiceRequest {
     }
 
 
-    public boolean isReturnsTree() {
-        return returnsTree;
-    }
+    public boolean isReturnsTree() { return returnsTree; }
 
+    public boolean isReturnsInboundConnections() { return returnsInboundConnections; }
+
+    public boolean isReturnsOutboundConnections() { return returnsOutboundConnections; }
 
     public List<ServiceParameter> getOriginalParameters() {
         return originalParameters;


### PR DESCRIPTION
connections=all (or no connections parameter): both connections and connecting metadata retrieved
connections=none: neither connections nor connecting metadata retrieved
connections=in: only connecting metadata retrieved
connections=out: only connections metadata retrieved

Will add tests in separate PR.