### PR TITLE
Update hasNextPage to return boolean

### DIFF
--- a/sdks/nodejs/lib/usergrid.js
+++ b/sdks/nodejs/lib/usergrid.js
@@ -1112,7 +1112,7 @@ var AUTH_NONE = 'NONE';
     var connectee = this.getEntityId(entity);
     if (!connectee) {
       if (typeof(callback) === 'function') {
-        var error = 'Error trying to delete object - no uuid specified.';
+        var error = 'Error trying to connect object - no uuid specified.';
         if (self._client.logging) {
           console.log(error);
         }

--- a/sdks/nodejs/lib/usergrid.js
+++ b/sdks/nodejs/lib/usergrid.js
@@ -2050,7 +2050,7 @@ Usergrid.Client.prototype.delete = function(opts, callback) {
   *  @return {boolean} returns true if there is a next page of data, false otherwise
   */
   Usergrid.Collection.prototype.hasNextPage = function () {
-    return (this._next);
+    return !!this._next;
   }
 
   /*


### PR DESCRIPTION
The `hasNextPage` method returned evaluation of its `_next` property,
which is either a string or null. Method documentation says it returns a
boolean value.

The result is now `_next` forced to boolean using `!!`.