### PR TITLE
USERGRID-992: organization-level configuration

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/util/CpNamingUtils.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/util/CpNamingUtils.java
@@ -78,6 +78,9 @@ public class CpNamingUtils {
     public static final String DELETED_APPLICATION_INFO = "deleted_org_application";
     public static final String DELETED_APPLICATION_INFOS = "deleted_org_applications";
 
+    public static final String ORG_CONFIG = "org_config";
+    public static final String ORG_CONFIGS = "org_configs";
+
     /**
      * The name of the map that holds our entity id->type mapping
      */

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/ApiResponse.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/ApiResponse.java
@@ -34,6 +34,8 @@ import java.util.UUID;
 
 import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.usergrid.management.OrganizationConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.apache.commons.lang.ClassUtils;
 import org.apache.commons.lang.StringUtils;
@@ -95,6 +97,7 @@ public class ApiResponse {
     private Map<String, List<String>> params;
     private List<AggregateCounterSet> counters;
     private ClientCredentialsInfo credentials;
+    private OrganizationConfig organizationConfig;
 
     protected Map<String, Object> properties = new TreeMap<String, Object>( String.CASE_INSENSITIVE_ORDER );
 
@@ -575,6 +578,17 @@ public class ApiResponse {
     public ApiResponse withCredentials( ClientCredentialsInfo credentials ) {
         this.credentials = credentials;
         return this;
+    }
+
+
+    @JsonProperty("configuration")
+    @JsonSerialize( include = Inclusion.NON_NULL )
+    public OrganizationConfig getOrganizationConfig() {
+        return organizationConfig;
+    }
+
+    public void setOrganizationConfig(OrganizationConfig organizationConfig) {
+        this.organizationConfig = organizationConfig;
     }
 
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ServiceResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ServiceResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.usergrid.management.OrganizationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -277,13 +278,24 @@ public class ServiceResource extends AbstractContextResource {
                returnInboundConnections = false;
                returnOutboundConnections = false;
            } else if ("in".equalsIgnoreCase(connectionQueryParm)) {
+                returnInboundConnections = true;
                returnOutboundConnections = false;
            } else if ("out".equalsIgnoreCase(connectionQueryParm)) {
                returnInboundConnections = false;
-           } else if (! "all".equalsIgnoreCase(connectionQueryParm)) {
-               // unrecognized variable
-               if (connectionQueryParm != null)
-                   logger.error( String.format( "Invalid connection query parameter=%s, ignoring.", connectionQueryParm));
+                returnOutboundConnections = true;
+            } else if ("all".equalsIgnoreCase(connectionQueryParm)) {
+                returnInboundConnections = true;
+                returnOutboundConnections = true;
+            } else {
+                if (connectionQueryParm != null) {
+                    // unrecognized parameter
+                    logger.error(String.format("Invalid connections query parameter=%s, ignoring.", connectionQueryParm));
+                }
+                // use the default query parameter functionality
+                OrganizationConfig orgConfig = management.getOrganizationConfigForApplication(services.getApplicationId());
+                String defaultConnectionQueryParm = orgConfig.getDefaultConnectionParam();
+                returnInboundConnections = (defaultConnectionQueryParm == "in") || (defaultConnectionQueryParm == "all");
+                returnOutboundConnections = (defaultConnectionQueryParm == "out") || (defaultConnectionQueryParm == "all");
            }
         }
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationResource.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.NullArgumentException;
 
 import org.apache.usergrid.corepersistence.util.CpNamingUtils;
 import org.apache.usergrid.management.ActivationState;
+import org.apache.usergrid.management.OrganizationConfig;
 import org.apache.usergrid.management.OrganizationInfo;
 import org.apache.usergrid.management.export.ExportService;
 import org.apache.usergrid.management.importer.ImportService;
@@ -39,6 +40,7 @@ import org.apache.usergrid.rest.exceptions.RedirectionException;
 import org.apache.usergrid.rest.management.organizations.applications.ApplicationsResource;
 import org.apache.usergrid.rest.management.organizations.users.UsersResource;
 import org.apache.usergrid.rest.security.annotations.RequireOrganizationAccess;
+import org.apache.usergrid.rest.security.annotations.RequireSystemAccess;
 import org.apache.usergrid.rest.utils.JSONPUtils;
 import org.apache.usergrid.security.oauth.ClientCredentialsInfo;
 import org.apache.usergrid.security.tokens.exceptions.TokenException;
@@ -360,5 +362,57 @@ public class OrganizationResource extends AbstractContextResource {
         return Response.status( SC_OK ).entity( entity).build();
     }
 
+
+    @RequireOrganizationAccess
+    @GET
+    @Path("config")
+    public JSONWithPadding getConfig( @Context UriInfo ui,
+                                      @QueryParam("callback") @DefaultValue("callback") String callback )
+            throws Exception {
+
+        logger.info( "Get configuration for organization: " + organization.getUuid() );
+
+        // TODO: check for super user, @RequireSystemAccess didn't work
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "get organization configuration" );
+
+        // TODO: check for super user
+
+        OrganizationConfig orgConfig =
+                management.getOrganizationConfigByUuid( organization.getUuid() );
+
+        response.setProperty( "configuration", management.getOrganizationConfigData( orgConfig ) );
+        // response.setOrganizationConfig( orgConfig );
+
+        return new JSONWithPadding( response, callback );
+    }
+
+
+    @RequireOrganizationAccess
+    @Consumes(MediaType.APPLICATION_JSON)
+    @PUT
+    @Path("config")
+    public JSONWithPadding putConfig( @Context UriInfo ui, Map<String, Object> json,
+                                       @QueryParam("callback") @DefaultValue("callback") String callback )
+            throws Exception {
+
+        logger.debug("Put configuration for organization: " + organization.getUuid());
+
+        ApiResponse response = createApiResponse();
+        response.setAction("put organization configuration");
+
+        // TODO: check for super user
+
+        // response.setParams(ui.getQueryParameters());
+
+        OrganizationConfig orgConfig =
+                management.getOrganizationConfigByUuid( organization.getUuid() );
+        orgConfig.addProperties(json);
+        management.updateOrganizationConfig(orgConfig);
+        response.setProperty( "configuration", management.getOrganizationConfigData( orgConfig ) );
+
+        return new JSONWithPadding( response, callback );
+    }
 
 }

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationsResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationsResource.java
@@ -64,6 +64,7 @@ public class OrganizationsResource extends AbstractContextResource {
     private static final Logger logger = LoggerFactory.getLogger( OrganizationsResource.class );
 
     public static final String ORGANIZATION_PROPERTIES = "properties";
+    public static final String ORGANIZATION_CONFIGURATION = "configuration";
 
     @Autowired
     private ApplicationCreator applicationCreator;

--- a/stack/services/src/main/java/org/apache/usergrid/management/ManagementService.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/ManagementService.java
@@ -341,6 +341,16 @@ public interface ManagementService {
 
     Map<String,Long> getEachCollectionSize(final UUID applicationId);
 
+    public OrganizationConfig getOrganizationConfigByName( String organizationName ) throws Exception;
+
+    public OrganizationConfig getOrganizationConfigByUuid( UUID id ) throws Exception;
+
+    public Map<String, Object> getOrganizationConfigData( OrganizationConfig organizationConfig ) throws Exception;
+
+    public OrganizationConfig getOrganizationConfigForApplication( UUID applicationId ) throws Exception;
+
+    public void updateOrganizationConfig( OrganizationConfig organizationConfig ) throws Exception;
+    
     /**
      * will delete all entities
      * @param applicationId

--- a/stack/services/src/main/java/org/apache/usergrid/management/OrganizationConfig.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/OrganizationConfig.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.usergrid.management;
+
+
+import java.util.*;
+
+import static org.apache.usergrid.persistence.Schema.PROPERTY_PATH;
+import static org.apache.usergrid.persistence.Schema.PROPERTY_UUID;
+
+
+public class OrganizationConfig {
+
+    public static final String DEFAULT_CONNECTION_PARAM_PROPERTY = "defaultConnectionParam";
+    private static final String DEFAULT_CONNECTION_PARAM_DEFAULT_VALUE = "all";
+
+    private static final String [] propertyNames = {
+            DEFAULT_CONNECTION_PARAM_PROPERTY
+    };
+
+    private static final String [] defaultValues = {
+            DEFAULT_CONNECTION_PARAM_DEFAULT_VALUE
+    };
+
+    private UUID id;
+    private String name;
+    private Map<String, Object> properties;
+
+
+    public OrganizationConfig() {
+    }
+
+
+    public OrganizationConfig(UUID id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+
+    public OrganizationConfig(Map<String, Object> properties) {
+        id = ( UUID ) properties.get( PROPERTY_UUID );
+        name = ( String ) properties.get( PROPERTY_PATH );
+    }
+
+
+    public OrganizationConfig(UUID id, String name, Map<String, Object> properties) {
+        this( id, name );
+        this.properties = properties;
+
+        // add default values to properties map
+        addDefaultsToProperties();
+    }
+
+    private void addDefaultsToProperties()  {
+        for (int i=0; i < propertyNames.length; i++) {
+            if (!properties.containsKey(propertyNames[i])) {
+                properties.put(propertyNames[i], defaultValues[i]);
+            }
+        }
+    }
+
+
+    public UUID getUuid() {
+        return id;
+    }
+
+
+    public void setUuid( UUID id ) {
+        this.id = id;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+
+    public void setName( String name ) {
+        this.name = name;
+    }
+
+
+    public String getDefaultConnectionParam() {
+        String defaultParam = DEFAULT_CONNECTION_PARAM_DEFAULT_VALUE;
+        if ( properties != null ) {
+            Object paramValue = properties.get( DEFAULT_CONNECTION_PARAM_PROPERTY );
+            if ( paramValue instanceof String ) {
+                defaultParam = ( String ) paramValue;
+            }
+        }
+        return defaultParam;
+    }
+
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( id == null ) ? 0 : id.hashCode() );
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        return result;
+    }
+
+
+    @Override
+    public boolean equals( Object obj ) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        OrganizationConfig other = (OrganizationConfig) obj;
+        if ( id == null ) {
+            if ( other.id != null ) {
+                return false;
+            }
+        }
+        else if ( !id.equals( other.id ) ) {
+            return false;
+        }
+        if ( name == null ) {
+            if ( other.name != null ) {
+                return false;
+            }
+        }
+        else if ( !name.equals( other.name ) ) {
+            return false;
+        }
+        return true;
+    }
+
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+
+    public void setProperties( Map<String, Object> properties ) {
+        this.properties = properties;
+
+        // add default values to properties map
+        addDefaultsToProperties();
+    }
+
+    public void addProperties( Map<String, Object> properties ) {
+        this.properties.putAll(properties);
+        /*for (Map.Entry<String,Object> entry : properties.entrySet()) {
+            if (entry.getValue() != null) {
+                // add to properties
+                this.properties.put(entry.getKey(), entry.getValue());
+            } else {
+                // remove from properties
+                this.properties.remove(entry.getKey());
+            }
+        }*/
+
+        // add default values to properties map
+        addDefaultsToProperties();
+    }
+}


### PR DESCRIPTION
1. Add organization config GET and PUT.
2. Use default connections parameter stored in organization config (if it exists) for limiting connection reads when retrieving an entity/collection.

Todo:
1. Fix organization config GET and PUT so that it requires superuser access (required USERGRID-645).
2. Organization config info should be cached.
3. Tests.