### PR TITLE
USERGRID-645: fix superuser access via token

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationResource.java
@@ -363,7 +363,7 @@ public class OrganizationResource extends AbstractContextResource {
     }
 
 
-    @RequireOrganizationAccess
+    @RequireSystemAccess
     @GET
     @Path("config")
     public JSONWithPadding getConfig( @Context UriInfo ui,
@@ -389,7 +389,7 @@ public class OrganizationResource extends AbstractContextResource {
     }
 
 
-    @RequireOrganizationAccess
+    @RequireSystemAccess
     @Consumes(MediaType.APPLICATION_JSON)
     @PUT
     @Path("config")
@@ -410,6 +410,9 @@ public class OrganizationResource extends AbstractContextResource {
                 management.getOrganizationConfigByUuid( organization.getUuid() );
         orgConfig.addProperties(json);
         management.updateOrganizationConfig(orgConfig);
+
+        // refresh orgConfig -- to pick up removed entries and defaults
+        orgConfig = management.getOrganizationConfigByUuid( organization.getUuid() );
         response.setProperty( "configuration", management.getOrganizationConfigData( orgConfig ) );
 
         return new JSONWithPadding( response, callback );

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/security/SecuredResourceFilterFactory.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/security/SecuredResourceFilterFactory.java
@@ -58,6 +58,7 @@ import static org.apache.usergrid.security.shiro.utils.SubjectUtils.isPermittedA
 import static org.apache.usergrid.security.shiro.utils.SubjectUtils.isPermittedAccessToOrganization;
 import static org.apache.usergrid.security.shiro.utils.SubjectUtils.isUser;
 import static org.apache.usergrid.security.shiro.utils.SubjectUtils.loginApplicationGuest;
+import static org.apache.usergrid.security.shiro.Realm.ROLE_SERVICE_ADMIN;
 
 
 @Component
@@ -299,7 +300,7 @@ public class SecuredResourceFilterFactory implements ResourceFilterFactory {
         public void authorize( ContainerRequest request ) {
             logger.debug( "SystemFilter.authorize" );
             try {
-                if ( !request.isUserInRole( "sysadmin" ) ) {
+                if ( !request.isUserInRole( ROLE_SERVICE_ADMIN ) ) {
                     logger.debug( "You are not the system admin." );
                     throw mappableSecurityException( "unauthorized", "No system access authorized",
                             SecurityException.REALM );
@@ -307,8 +308,8 @@ public class SecuredResourceFilterFactory implements ResourceFilterFactory {
             }
             catch ( IllegalStateException e ) {
                 logger.debug( "This is an invalid state",e );
-                if ( ( request.getUserPrincipal() == null ) || !"sysadmin"
-                        .equals( request.getUserPrincipal().getName() ) ) {
+                if ( ( request.getUserPrincipal() == null ) ||
+                        !ROLE_SERVICE_ADMIN.equals( request.getUserPrincipal().getName() ) ) {
                     throw mappableSecurityException( "unauthorized", "No system access authorized",
                             SecurityException.REALM );
                 }

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/security/shiro/filters/BasicAuthSecurityFilter.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/security/shiro/filters/BasicAuthSecurityFilter.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import org.apache.shiro.codec.Base64;
+import static org.apache.usergrid.security.shiro.Realm.ROLE_SERVICE_ADMIN;
 
 import com.sun.jersey.spi.container.ContainerRequest;
 
@@ -80,7 +81,7 @@ public class BasicAuthSecurityFilter extends SecurityFilter {
             principal = new Principal() {
                 @Override
                 public String getName() {
-                    return "sysadmin";
+                    return ROLE_SERVICE_ADMIN;
                 }
             };
         }
@@ -94,7 +95,7 @@ public class BasicAuthSecurityFilter extends SecurityFilter {
 
         @Override
         public boolean isUserInRole( String role ) {
-            return role.equals( "sysadmin" );
+            return role.equals( ROLE_SERVICE_ADMIN );
         }
 
 

--- a/stack/services/src/main/java/org/apache/usergrid/security/shiro/Realm.java
+++ b/stack/services/src/main/java/org/apache/usergrid/security/shiro/Realm.java
@@ -306,6 +306,30 @@ public class Realm extends AuthorizingRealm {
 
                     grant( info, principal,
                             getPermissionFromPath( emf.getManagementAppId(), "get,put,post,delete", "/**" ) );
+
+                    // get all organizations
+                    try {
+
+                        Map<UUID, String> allOrganizations = management.getOrganizations();
+
+                        if ( allOrganizations != null ) {
+                            for ( UUID id : allOrganizations.keySet() ) {
+                                grant( info, principal, "organizations:admin,access,get,put,post,delete:" + id );
+                            }
+                            organizationSet.putAll(allOrganizations);
+
+                            Map<UUID, String> allApplications =
+                                management.getApplicationsForOrganizations( allOrganizations.keySet() );
+                            if ( ( allApplications != null ) && !allApplications.isEmpty() ) {
+                                grant( info, principal, "applications:admin,access,get,put,post,delete:" + StringUtils
+                                    .join( allApplications.keySet(), ',' ) );
+                                applicationSet.putAll( allApplications );
+                            }
+                        }
+                    }
+                    catch ( Exception e ) {
+                        logger.error( "Unable to construct superuser permissions", e );
+                    }
                 }
                 else {
 


### PR DESCRIPTION
1. Superuser access via token now works. Some code was checking for hardcoded string "sysadmin" -- superuser role is now "service-admin".
2. Superuser token should now be granted access to all orgs and apps.
3. Locked down org config GET/PUT to superusers only.

Basic auth superuser still does not have access to orgs/apps. Org config GET/PUT requires both org access to specified org and superuser access, so token must be used for org config.