### PR TITLE
Update the visibility timeout used when taking messages from SQS as i…

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/IndexProcessorFig.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/IndexProcessorFig.java
@@ -62,11 +62,10 @@ public interface IndexProcessorFig extends GuicyFig {
 
     /**
      * Set the visibility timeout for messages received from the queue. (in milliseconds).
-     * AWS default is also currently 30 seconds.  Received messages will remain 'in flight' until
-     * they are ack'd(deleted) or this timeout occurs.  If the timeout occurs, the messages will become
-     * visible again for re-processing.
+     * Received messages will remain 'in flight' until they are ack'd(deleted) or this timeout occurs.
+     * If the timeout occurs, the messages will become visible again for re-processing.
      */
-    @Default( "30000" )
+    @Default( "5000" ) // 5 seconds
     @Key( INDEX_QUEUE_VISIBILITY_TIMEOUT )
     int getIndexQueueVisibilityTimeout();
 

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/QueueFig.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/QueueFig.java
@@ -76,10 +76,10 @@ public interface QueueFig extends GuicyFig {
     int getAsyncQueueSize();
 
     /**
-     * Set the visibility timeout for faster retries
+     * Set the visibility timeout (in milliseconds) for faster retries
      * @return
      */
     @Key( "usergrid.queue.visibilityTimeout" )
-    @Default("10")
-    String getVisibilityTimeout();
+    @Default("5000") // 5 seconds
+    int getVisibilityTimeout();
 }

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/SNSQueueManagerImpl.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/SNSQueueManagerImpl.java
@@ -351,7 +351,7 @@ public class SNSQueueManagerImpl implements QueueManager {
 
         ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(url);
         receiveMessageRequest.setMaxNumberOfMessages(limit);
-        receiveMessageRequest.setVisibilityTimeout(transactionTimeout / 1000);
+        receiveMessageRequest.setVisibilityTimeout(Math.max(1, transactionTimeout / 1000));
         receiveMessageRequest.setWaitTimeSeconds(waitTime / 1000);
 
         try {

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/util/AmazonNotificationUtils.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/util/AmazonNotificationUtils.java
@@ -61,10 +61,12 @@ public class AmazonNotificationUtils {
             .format( "{\"maxReceiveCount\":\"%s\"," + " \"deadLetterTargetArn\":\"%s\"}", fig.getQueueDeliveryLimit(),
                 deadletterArn );
 
+        final String visibilityTimeoutInSeconds = String.valueOf(Math.max(1, fig.getVisibilityTimeout() / 1000));
+
         final Map<String, String> queueAttributes = new HashMap<>( 2 );
         queueAttributes.put( "MessageRetentionPeriod", fig.getRetentionPeriod() );
         queueAttributes.put( "RedrivePolicy", redrivePolicy );
-        queueAttributes.put( "VisibilityTimeout", fig.getVisibilityTimeout()  );
+        queueAttributes.put( "VisibilityTimeout", visibilityTimeoutInSeconds );
 
         CreateQueueRequest createQueueRequest = new CreateQueueRequest().
                                                                             withQueueName( queueName )


### PR DESCRIPTION
…t overrides the queue's configured/default timeout.  Also change the queue's visibility timeout property to be exposed as milliseconds for consistency.