### PR TITLE
For USERGRID-1058: Add ability to generate master Jacoco report for all stack modules

### DIFF
--- a/stack/Coverage.md
+++ b/stack/Coverage.md
@@ -1,7 +1,11 @@
 Generating Coverage reports
 ---
 
-run this command: mvn verify jacoco:report
+To generate Jacoco coverage reports for Usergrid, run this command in the usergrid/stack directory:
+
+    mvn verify jacoco:report
+
+Note that all tests must pass, or some Jacoco files will be missing and report generation is likely to fail complete.
 
 Once you do that the below coverage reports will be available.
 
@@ -18,4 +22,15 @@ Coverage reports
 * [./corepersistence/queue/target/site/jacoco/index.html](file:./corepersistence/queue/target/site/jacoco/index.html)
 * [./services/target/site/jacoco/index.html](file:./services/target/site/jacoco/index.html)
 * [./rest/target/site/jacoco/index.html](file:./services/target/site/jacoco/index.html)
+
+Master Coverage report
+---
+
+After you run the above command to generate Jacoco reports, you can run this command to generate a master report:
+
+    mvn -f jacoco-pom.xml install
+
+The master report will be available at this link:
+
+* [./target/coverage-report/html/index.html](file:./target/coverage-report/html/index.html)
 

--- a/stack/core/pom.xml
+++ b/stack/core/pom.xml
@@ -467,7 +467,7 @@
       <dependency>
           <groupId>org.apache.usergrid</groupId>
           <artifactId>cache</artifactId>
-          <version>2.1.0-SNAPSHOT</version>
+          <version>2.1.1-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/stack/corepersistence/collection/pom.xml
+++ b/stack/corepersistence/collection/pom.xml
@@ -32,24 +32,13 @@
 
   <dependencies>
 
-<!--    <dependency>
-      <groupId>org.safehaus.chop</groupId>
-      <artifactId>chop-api</artifactId>
-      <version>${chop.version}</version>
-    </dependency>-->
-
     <!-- Google Guice Integration Test Injectors -->
-
 
     <dependency>
       <groupId>org.apache.usergrid</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-
-
-
 
     <!-- tests -->
 
@@ -61,14 +50,12 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-
 
   </dependencies>
 </project>

--- a/stack/corepersistence/graph/pom.xml
+++ b/stack/corepersistence/graph/pom.xml
@@ -103,15 +103,8 @@
                     <argLine>
                         -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec
                     </argLine>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- We want to exclude any chop tests or stress tests.  They kill the embedded cassandra and
-                    aren't intended to be part of the build process-->
+                    <!-- We want to exclude any chop tests or stress tests.
+                    They kill the embedded cassandra and aren't intended to be part of the build process-->
                     <excludes>
                         <exclude>**/*ChopTest.java</exclude>
                         <exclude>**/*LoadTest.java</exclude>

--- a/stack/corepersistence/pom.xml
+++ b/stack/corepersistence/pom.xml
@@ -95,29 +95,86 @@ limitations under the License.
 
         <pluginManagement>
             <plugins>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*Test.java</include>
+                            <include>**/*IT.java</include>
+                        </includes>
+                        <systemPropertyVariables>
+                            <archaius.deployment.environment>UNIT</archaius.deployment.environment>
+                        </systemPropertyVariables>
+                        <argLine>-Xms2G -Xmx4G</argLine>
+                    </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
+
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>default-report</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>default-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <rule>
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <limit>
+                                                <counter>COMPLEXITY</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <!-- we should increase this as our coverage increases -->
+                                                <minimum>0.10</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+
+                    <configuration>
+                        <fileSets>
+                            <fileSet>
+                                <directory>${project.build.directory}</directory>
+                                <includes>
+                                    <include>jacoco.exec</include>
+                                </includes>
+                            </fileSet>
+                        </fileSets>
+                    </configuration>
+
+                </plugin>
+
             </plugins>
         </pluginManagement>
 
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*IT.java</include>
-                    </includes>
-                    <systemPropertyVariables>
-                        <archaius.deployment.environment>UNIT</archaius.deployment.environment>
-                    </systemPropertyVariables>
-                    <argLine>-Xms2G -Xmx4G</argLine>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -132,7 +189,6 @@ limitations under the License.
                     </execution>
                 </executions>
             </plugin>
-
 
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/stack/corepersistence/queryindex/pom.xml
+++ b/stack/corepersistence/queryindex/pom.xml
@@ -51,6 +51,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
 
                 <configuration>
+                    <argLine>
+                        -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec
+                    </argLine>
                     <includes>
                         <include>**/*IT.java</include>
                         <include>**/*Test.java</include>
@@ -59,20 +62,8 @@
                     <excludes>
                         <exclude>**/IndexLoadTestsIT.java</exclude>
                     </excludes>
-
                 </configuration>
 
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>
-                        -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec
-                    </argLine>
-                </configuration>
             </plugin>
 
         </plugins>

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -1536,14 +1536,13 @@
                     </goals>
                     <configuration>
                         <rules>
-                            <!--  implementation is needed only for Maven 2  -->
-                            <rule implementation="org.jacoco.maven.RuleConfiguration">
+                            <rule>
                                 <element>BUNDLE</element>
                                 <limits>
-                                    <!--  implementation is needed only for Maven 2  -->
-                                    <limit implementation="org.jacoco.report.check.Limit">
+                                    <limit>
                                         <counter>COMPLEXITY</counter>
                                         <value>COVEREDRATIO</value>
+                                        <!-- we should increase this as our coverage increases -->
                                         <minimum>0.30</minimum>
                                     </limit>
                                 </limits>
@@ -1552,6 +1551,17 @@
                     </configuration>
                 </execution>
             </executions>
+
+            <configuration>
+                <fileSets>
+                    <fileSet>
+                        <directory>${project.build.directory}</directory>
+                        <includes>
+                            <include>jacoco.exec</include>
+                        </includes>
+                    </fileSet>
+                </fileSets>
+            </configuration>
 
         </plugin>
 
@@ -1670,6 +1680,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.10</version>
         <configuration>
           <configLocation>usergrid/checkstyle.xml</configLocation>
         </configuration>

--- a/stack/test-utils/pom.xml
+++ b/stack/test-utils/pom.xml
@@ -242,7 +242,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -269,13 +268,6 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jsp-api</artifactId>
         </dependency>
-
-
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-test</artifactId>
-        </dependency>
-
 
     </dependencies>
 


### PR DESCRIPTION
The Jacoco Maven plugin generates a separate jacoco.exec data file for each of our Maven modules and cannot produce a combined "master" report.  The plugin can generate an merged data file, but cannot easily create a merged report. So, we use the Maven plugin to produce the Jacoco data files, but we new a an Ant-task to merge the data files and produce a merged report. 

See the Coverage.md file for instructions on creating Javaco module and the master report.

https://issues.apache.org/jira/browse/USERGRID-1058