### PR TITLE
Make Jacoco optional via Maven profile

### DIFF
--- a/stack/Coverage.md
+++ b/stack/Coverage.md
@@ -1,13 +1,17 @@
 Generating Coverage reports
 ---
 
-To generate Jacoco coverage reports for Usergrid, run this command in the usergrid/stack directory:
+To generate Jacoco coverage reports for Usergrid, do a build that runs the tests:
 
-    mvn verify jacoco:report
+For example:
+
+    mvn install
+
 
 Note that all tests must pass, or some Jacoco files will be missing and report generation is likely to fail complete.
 
 Once you do that the below coverage reports will be available.
+
 
 Coverage reports
 ---
@@ -23,6 +27,7 @@ Coverage reports
 * [./services/target/site/jacoco/index.html](file:./services/target/site/jacoco/index.html)
 * [./rest/target/site/jacoco/index.html](file:./services/target/site/jacoco/index.html)
 
+
 Master Coverage report
 ---
 
@@ -33,4 +38,3 @@ After you run the above command to generate Jacoco reports, you can run this com
 The master report will be available at this link:
 
 * [./target/coverage-report/html/index.html](file:./target/coverage-report/html/index.html)
-

--- a/stack/core/pom.xml
+++ b/stack/core/pom.xml
@@ -76,42 +76,9 @@
 
     <plugins>
 
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire.plugin.version}</version>
-            <configuration>
-                <systemPropertyVariables>
-                    <storage-config>${basedir}/src/test/conf</storage-config>
-                    <target.directory>${project.build.directory}</target.directory>
-                </systemPropertyVariables>
-                <parallel>methods</parallel>
-                <forkCount>${usergrid.it.forkCount}</forkCount>
-                <threadCount>${usergrid.it.threads}</threadCount>
-                <reuseForks>true</reuseForks>
-                <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
-                <!-- see this page for documentation on classloading issues http://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html -->
-                <!--<useSystemClassLoader>false</useSystemClassLoader>-->
-                <!--<useManifestOnlyJar>false</useManifestOnlyJar>-->
-                <includes>
-                    <include>**/*IT.java</include>
-                    <include>**/*Test.java</include>
-                </includes>
-
-            </configuration>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.maven.surefire</groupId>
-                    <artifactId>${surefire.plugin.artifactName}</artifactId>
-                    <version>${surefire.plugin.version}</version>
-                </dependency>
-                <!--<dependency>-->
-                    <!--<groupId>org.codehaus.plexus</groupId>-->
-                    <!--<artifactId>plexus-utils</artifactId>-->
-                    <!--<version>3.0.21</version>-->
-                <!--</dependency>-->
-            </dependencies>
-        </plugin>
+      <!--
+      Do not need to configure surefire plugin here, parent POM configuration is sufficient.
+      -->
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -131,33 +98,6 @@
           </execution>
         </executions>
       </plugin>
-
-
-<!--            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.usergrid.chop</groupId>
-                <artifactId>chop-maven-plugin</artifactId>
-                <version>2.0.0-SNAPSHOT</version>
-                <configuration>
-                    <username>${chop.coordinator.username}</username>
-                    <password>${chop.coordinator.password}</password>
-                    <endpoint>https://${chop.coordinator.url}:8443</endpoint>
-                    <testPackageBase>ctest</testPackageBase>
-                    <runnerCount>1</runnerCount>
-                </configuration>
-            </plugin>-->
 
     </plugins>
   </build>
@@ -497,24 +437,8 @@
 
   </dependencies>
 
-<!--
-    <profiles>
-        <profile>
-            <id>jacoco</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
-                        <configuration>
-                            <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
--->
+  <!--
+  Do not need jacoco profile here because we do not override the surefire plugin in this POM
+  -->
 
 </project>

--- a/stack/core/pom.xml
+++ b/stack/core/pom.xml
@@ -89,7 +89,7 @@
                 <forkCount>${usergrid.it.forkCount}</forkCount>
                 <threadCount>${usergrid.it.threads}</threadCount>
                 <reuseForks>true</reuseForks>
-                <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} </argLine>
+                <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
                 <!-- see this page for documentation on classloading issues http://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html -->
                 <!--<useSystemClassLoader>false</useSystemClassLoader>-->
                 <!--<useManifestOnlyJar>false</useManifestOnlyJar>-->
@@ -496,5 +496,25 @@
     </dependency>
 
   </dependencies>
+
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
 
 </project>

--- a/stack/corepersistence/collection/pom.xml
+++ b/stack/corepersistence/collection/pom.xml
@@ -15,21 +15,6 @@
   <artifactId>collection</artifactId>
   <name>Usergrid Collection</name>
 
-  <build>
-
-    <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire.plugin.version}</version>
-            <configuration>
-                <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
-            </configuration>
-        </plugin>
-    </plugins>
-
-  </build>
-
   <dependencies>
 
     <!-- Google Guice Integration Test Injectors -->
@@ -58,4 +43,25 @@
     </dependency>
 
   </dependencies>
+
+    <!--
+        <profiles>
+            <profile>
+                <id>jacoco</id>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <version>${surefire.plugin.version}</version>
+                            <configuration>
+                                <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
+        </profiles>
+    -->
+
 </project>

--- a/stack/corepersistence/common/pom.xml
+++ b/stack/corepersistence/common/pom.xml
@@ -12,22 +12,6 @@
   <artifactId>common</artifactId>
   <name>Usergrid Common</name>
 
-
-    <build>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-
-    </build>
-
   <dependencies>
 
     <dependency>
@@ -187,5 +171,23 @@
       <version>${metrics.version}</version>
     </dependency>
   </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/stack/corepersistence/graph/pom.xml
+++ b/stack/corepersistence/graph/pom.xml
@@ -92,29 +92,23 @@
 
   </dependencies>
 
-    <build>
 
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>
-                        -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec
-                    </argLine>
-                    <!-- We want to exclude any chop tests or stress tests.
-                    They kill the embedded cassandra and aren't intended to be part of the build process-->
-                    <excludes>
-                        <exclude>**/*ChopTest.java</exclude>
-                        <exclude>**/*LoadTest.java</exclude>
-                        <exclude>**/*StressTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-        </plugins>
-
-    </build>
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/stack/corepersistence/map/pom.xml
+++ b/stack/corepersistence/map/pom.xml
@@ -31,22 +31,6 @@ limitations under the License.
   <artifactId>map</artifactId>
   <name>Usergrid Map</name>
 
-
-    <build>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-
-    </build>
-
   <dependencies>
 
 
@@ -77,8 +61,6 @@ limitations under the License.
     </dependency>
 
 
-
-
     <dependency>
       <groupId>org.apache.usergrid</groupId>
       <artifactId>collection</artifactId>
@@ -87,5 +69,23 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/stack/corepersistence/model/pom.xml
+++ b/stack/corepersistence/model/pom.xml
@@ -12,22 +12,6 @@
     <artifactId>model</artifactId>
     <name>Usergrid Model</name>
 
-
-    <build>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-
-    </build>
-
     <!-- Runtime Dependencies -->
     <dependencies>
 
@@ -98,5 +82,25 @@
       </dependency>
 
     </dependencies>
+
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
 
 </project>

--- a/stack/corepersistence/pom.xml
+++ b/stack/corepersistence/pom.xml
@@ -29,6 +29,7 @@ limitations under the License.
     <version>2.1.1-SNAPSHOT</version>
 
   <profiles>
+
     <!-- better to have keep this sonar profile in your maven settings.xml -->
     <profile>
       <id>sonar</id>
@@ -42,6 +43,22 @@ limitations under the License.
         <sonar.jdbc.password>sonar</sonar.jdbc.password>
       </properties>
     </profile>
+
+      <profile>
+          <id>jacoco</id>
+          <build>
+              <plugins>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-surefire-plugin</artifactId>
+                      <version>${surefire.plugin.version}</version>
+                      <configuration>
+                          <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </build>
+      </profile>
 
   </profiles>
 

--- a/stack/corepersistence/queryindex/pom.xml
+++ b/stack/corepersistence/queryindex/pom.xml
@@ -51,9 +51,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
 
                 <configuration>
-                    <argLine>
-                        -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec
-                    </argLine>
                     <includes>
                         <include>**/*IT.java</include>
                         <include>**/*Test.java</include>
@@ -168,5 +165,25 @@
       </dependency>
 
     </dependencies>
+
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
 
 </project>

--- a/stack/corepersistence/queue/pom.xml
+++ b/stack/corepersistence/queue/pom.xml
@@ -33,22 +33,6 @@
 
   <name>Usergrid Queue</name>
 
-
-    <build>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
-                <configuration>
-                    <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-
-    </build>
-
   <dependencies>
 
 
@@ -107,5 +91,24 @@
 
   </dependencies>
 
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
 
 </project>

--- a/stack/jacoco-pom.xml
+++ b/stack/jacoco-pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.usergrid</groupId>
+    <artifactId>usergrid-coverage-report</artifactId>
+    <version>1.0</version>
+    <name>Usergrid Coverage Report</name>
+    <description>Merges module coverage reports into one aggregated file</description>
+    <packaging>pom</packaging>
+
+    <properties>
+        <jacoco.version>0.7.5.201505241946</jacoco.version>
+    </properties>
+
+    <build>
+
+        <plugins>
+
+            <!-- Jacoco Ant plugin > Jacoco Maven Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Execute an ant task within maven -->
+                                <echo message="Generating JaCoCo Reports" />
+                                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                    <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
+                                </taskdef>
+                                <mkdir dir="${basedir}/target/coverage-report" />
+                                <report>
+
+                                    <executiondata>
+                                        <fileset dir="corepersistence/collection/target">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="rest/target">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                    </executiondata>
+
+                                    <structure name="jacoco-multi Coverage Project">
+                                        <group name="jacoco-multi">
+                                            <classfiles>
+                                                <fileset dir="corepersistence/cache/target/classes" />
+                                                <fileset dir="corepersistence/collection/target/classes" />
+                                                <fileset dir="corepersistence/common/target/classes" />
+                                                <fileset dir="corepersistence/graph/target/classes" />
+
+                                                <fileset dir="corepersistence/map/target/classes" />
+                                                <fileset dir="corepersistence/model/target/classes" />
+                                                <fileset dir="corepersistence/queryindex/target/classes" />
+                                                <fileset dir="corepersistence/queue/target/classes" />
+
+                                                <fileset dir="core/target/classes" />
+                                                <fileset dir="services/target/classes" />
+                                                <fileset dir="rest/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="corepersistence/cache/src" />
+                                                <fileset dir="corepersistence/collection/src" />
+                                                <fileset dir="corepersistence/common/src" />
+                                                <fileset dir="corepersistence/graph/src" />
+                                                <fileset dir="corepersistence/map/src" />
+                                                <fileset dir="corepersistence/model/src" />
+                                                <fileset dir="corepersistence/queryindex/src" />
+                                                <fileset dir="corepersistence/queue/src" />
+                                                <fileset dir="core/src" />
+                                                <fileset dir="services/src" />
+                                                <fileset dir="rest/src" />
+                                            </sourcefiles>
+                                        </group>
+
+                                    </structure>
+                                    <html destdir="${basedir}/target/coverage-report/html" />
+                                    <xml destfile="${basedir}/target/coverage-report/coverage-report.xml" />
+                                    <csv destfile="${basedir}/target/coverage-report/coverage-report.csv" />
+                                </report>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>org.jacoco.ant</artifactId>
+                        <version>${jacoco.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+</project>
+

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -578,142 +578,6 @@
         </exclusions>
       </dependency>
 
-      <!-- Sun and Javax Package Dependencies -->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey</groupId>-->
-        <!--<artifactId>jersey-core</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey</groupId>-->
-        <!--<artifactId>jersey-json</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-        <!--<exclusions>-->
-          <!--<exclusion>-->
-            <!--<groupId>org.codehaus.jettison</groupId>-->
-            <!--<artifactId>jettison</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.codehaus.jackson</groupId>-->
-            <!--<artifactId>jackson-core-asl</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.codehaus.jackson</groupId>-->
-            <!--<artifactId>jackson-mapper-asl</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.codehaus.jackson</groupId>-->
-            <!--<artifactId>jackson-jaxrs</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.codehaus.jackson</groupId>-->
-            <!--<artifactId>jackson-xc</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>javax.activation</groupId>-->
-            <!--<artifactId>activation</artifactId>-->
-          <!--</exclusion>-->
-        <!--</exclusions>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey</groupId>-->
-        <!--<artifactId>jersey-client</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey</groupId>-->
-        <!--<artifactId>jersey-server</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey</groupId>-->
-        <!--<artifactId>jersey-grizzly2</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>org.glassfish.grizzly</groupId>-->
-        <!--<artifactId>grizzly-http-servlet-server</artifactId>-->
-        <!--<version>2.1.2</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey.contribs</groupId>-->
-        <!--<artifactId>jersey-spring</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-        <!--<exclusions>-->
-          <!--<exclusion>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring-aop</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring-core</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring-beans</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring-context</artifactId>-->
-          <!--</exclusion>-->
-
-          <!--<exclusion>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring-web</artifactId>-->
-          <!--</exclusion>-->
-        <!--</exclusions>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey.contribs</groupId>-->
-        <!--<artifactId>jersey-multipart</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey.contribs.jersey-oauth</groupId>-->
-        <!--<artifactId>oauth-signature</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey.contribs.jersey-oauth</groupId>-->
-        <!--<artifactId>oauth-server</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey.jersey-test-framework</groupId>-->
-        <!--<artifactId>jersey-test-framework-external</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
-      <!--<dependency>-->
-        <!--<groupId>com.sun.jersey.jersey-test-framework</groupId>-->
-        <!--<artifactId>jersey-test-framework-core</artifactId>-->
-        <!--<version>${jersey-version}</version>-->
-      <!--</dependency>-->
-
       <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>javax.mail</artifactId>
@@ -1436,15 +1300,13 @@
 
     <plugins>
 
-
                 <!--
-                        <plugin>
-                          <groupId>com.structure101.java</groupId>
-                          <artifactId>maven-structure101-plugin</artifactId>
-                          <version>1.1</version>
-                        </plugin>
+                <plugin>
+                   <groupId>com.structure101.java</groupId>
+                   <artifactId>maven-structure101-plugin</artifactId>
+                   <version>1.1</version>
+                </plugin>
                 -->
-
 
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
@@ -1472,16 +1334,15 @@
                           <forkCount>${usergrid.it.forkCount}</forkCount>
                           <reuseForks>${usergrid.it.reuseForks}</reuseForks>
                           <threadCount>${usergrid.it.forkCount}</threadCount>
-                          <!-- see this page for documentation on classloading issues http://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html -->
-                          <useSystemClassLoader>false</useSystemClassLoader>
-                          <argLine>-Xmx${ug.heapmax} -Xms${ug.heapmin}  -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
-                          <!--<argLine>-Xmx${ug.heapmax} -Xms${ug.heapmin} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec  -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>-->
-                          <testFailureIgnore>false</testFailureIgnore>
 
+                          <!-- see this page for documentation on classloading issues
+                          http://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html -->
+                          <useSystemClassLoader>false</useSystemClassLoader>
+
+                          <argLine>-Xmx${ug.heapmax} -Xms${ug.heapmin}  -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
                           <systemPropertyVariables>
                               <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
                           </systemPropertyVariables>
-
                       </configuration>
 
                       <!-- TODO, we may need an exclusion. Appears to be a classloader bug
@@ -1544,7 +1405,7 @@
                                         <counter>COMPLEXITY</counter>
                                         <value>COVEREDRATIO</value>
                                         <!-- we should increase this as our coverage increases -->
-                                        <minimum>0.30</minimum>
+                                        <minimum>0.15</minimum>
                                     </limit>
                                 </limits>
                             </rule>

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -1711,6 +1711,25 @@
     </plugins>
   </reporting>
 
+
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 <!--
     <repositories>
         <repository>

--- a/stack/rest/pom.xml
+++ b/stack/rest/pom.xml
@@ -36,34 +36,6 @@
         <catalina.jmx.port>8089</catalina.jmx.port>
     </properties>
 
-    <!-- profile that arquillian uses when it builds/starts tomcat -->
-    <profiles>
-
-        <!--
-        <profile>
-            <id>arquillian-tomcat</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-remote-7</artifactId>
-                    <version>1.0.0.CR7</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.eu.ingwar.tools</groupId>
-                    <artifactId>arquillian-suite-extension</artifactId>
-                    <version>1.1.1</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        -->
-
-    </profiles>
-
     <build>
         <finalName>ROOT</finalName>
 
@@ -105,7 +77,7 @@
                     <threadCount>${usergrid.rest.threads}</threadCount>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <reuseForks>true</reuseForks>
-                    <argLine>-Dwebapp.directory=${basedir}/src/main/webapp -Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar -Djava.util.logging.config.file=${basedir}/src/test/resources/logging.properties ${ug.argline}
+                    <argLine>-Dwebapp.directory=${basedir}/src/main/webapp -Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8  -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar -Djava.util.logging.config.file=${basedir}/src/test/resources/logging.properties ${ug.argline}
                     </argLine>
                     <includes>
                         <include>**/*IT.java</include>
@@ -423,5 +395,25 @@
         </dependency>
 
     </dependencies>
+
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
 
 </project>

--- a/stack/rest/pom.xml
+++ b/stack/rest/pom.xml
@@ -62,12 +62,14 @@
 
         <plugins>
 
+            <!--
+            Need to override parent's surefire plugin here to set system properties.
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.plugin.version}</version>
                 <configuration>
-                    <!--<skipTests>true</skipTests>-->
                     <systemPropertyVariables>
                         <storage-config>${basedir}/src/test/conf</storage-config>
                         <target.directory>${project.build.directory}</target.directory>
@@ -396,7 +398,9 @@
 
     </dependencies>
 
-<!--
+    <!--
+    Need jacoco profile here because we override the parent's surefire plugin settings above.
+    -->
     <profiles>
         <profile>
             <id>jacoco</id>
@@ -407,13 +411,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.plugin.version}</version>
                         <configuration>
-                            <argLine>-javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec  -Dwebapp.directory=${basedir}/src/main/webapp -Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8  -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar -Djava.util.logging.config.file=${basedir}/src/test/resources/logging.properties ${ug.argline}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
--->
 
 </project>

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/security/shiro/session/HttpRequestSessionManager.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/security/shiro/session/HttpRequestSessionManager.java
@@ -25,7 +25,7 @@ import org.apache.shiro.session.Session;
 import org.apache.shiro.session.SessionException;
 import org.apache.shiro.session.mgt.SessionContext;
 import org.apache.shiro.session.mgt.SessionKey;
-import org.apache.shiro.session.mgt.SessionManager;
+import org.apache.shiro.web.session.mgt.WebSessionManager;
 import org.apache.shiro.web.util.WebUtils;
 
 
@@ -34,7 +34,7 @@ import org.apache.shiro.web.util.WebUtils;
  * on each request. This necessarily means that a mechanism like form-based authentication isn't viable, but the
  * intention is primarily for uses in stateless apis.
  */
-public class HttpRequestSessionManager implements SessionManager {
+public class HttpRequestSessionManager implements WebSessionManager {
 
     static final String REQUEST_ATTRIBUTE_KEY = "__SHIRO_REQUEST_SESSION";
 
@@ -84,5 +84,10 @@ public class HttpRequestSessionManager implements SessionManager {
 
     protected Session createSession( HttpServletRequest request, String host ) {
         return new HttpServletRequestSession( request, host );
+    }
+
+    @Override
+    public boolean isServletContainerSessions() {
+        return false;
     }
 }

--- a/stack/services/pom.xml
+++ b/stack/services/pom.xml
@@ -94,7 +94,7 @@
                 <threadCount>${usergrid.it.threads}</threadCount>
                 <reuseForks>${usergrid.it.reuseForks}</reuseForks>
                 <useSystemClassLoader>false</useSystemClassLoader>
-                <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}
+                <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}
                 </argLine>
                 <includes>
                     <include>**/*IT.java</include>
@@ -474,4 +474,25 @@
       </dependency>
 
   </dependencies>
+
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-Dtest.barrier.timestamp=${maven.build.timestamp} -Dtest.clean.storage=true -Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline} -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
+
 </project>

--- a/stack/services/pom.xml
+++ b/stack/services/pom.xml
@@ -79,11 +79,14 @@
     </testResources>
 
     <plugins>
+
+        <!--
+        Need to override parent's surefire plugin here to set system properties.
+        -->
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${surefire.plugin.version}</version>
-
             <configuration>
                 <systemPropertyVariables>
                     <storage-config>${basedir}/src/test/conf</storage-config>
@@ -100,8 +103,6 @@
                     <include>**/*IT.java</include>
                     <include>**/*Test.java</include>
                 </includes>
-
-                <!-- exclude our serial tests -->
                 <excludes>
                     <exclude>**/*Scheduler*IT.java</exclude>
                     <exclude>**/*Notification*IT.java</exclude>
@@ -123,6 +124,7 @@
             </dependencies>
 
         </plugin>
+
     </plugins>
   </build>
 
@@ -475,7 +477,9 @@
 
   </dependencies>
 
-<!--
+    <!--
+    Need jacoco profile here because we override the parent's surefire plugin settings above.
+    -->
     <profiles>
         <profile>
             <id>jacoco</id>
@@ -493,6 +497,5 @@
             </build>
         </profile>
     </profiles>
--->
 
 </project>

--- a/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
@@ -1728,7 +1728,9 @@ public class ManagementServiceImpl implements ManagementService {
                     + ")</a> restored an application named " + appInfo.getName(), null );
         }
 
-
+        ScopedCache scopedCache = cacheFactory.getScopedCache(
+            new CacheScope( new SimpleId( CpNamingUtils.MANAGEMENT_APPLICATION_ID, "application" )));
+        scopedCache.invalidate();
 
         return new ApplicationInfo( applicationId, appInfo.getName() );
     }

--- a/stack/test-utils/pom.xml
+++ b/stack/test-utils/pom.xml
@@ -271,4 +271,24 @@
 
     </dependencies>
 
+<!--
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
+
 </project>

--- a/stack/test-utils/pom.xml
+++ b/stack/test-utils/pom.xml
@@ -41,37 +41,35 @@
             </testResource>
         </testResources>
 
-
-
-
         <plugins>
-          <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-surefire-plugin</artifactId>
-                 <configuration>
-                   <systemPropertyVariables>
-                     <storage-config>${basedir}/src/test/conf</storage-config>
-                     <target.directory>${project.build.directory}</target.directory>
-                   </systemPropertyVariables>
-                   <parallel>classes</parallel>
-                   <forkCount>${usergrid.it.forkCount}</forkCount>
-                   <threadCount>${usergrid.it.threads}</threadCount>
-                   <threadCountClasses></threadCountClasses>
-                   <reuseForks>true</reuseForks>
-                   <argLine>-Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
 
-
-                    <includes>
-                       <include>**/CassandraResourceITSuite.java</include>
-                       <!-- <include>**/CassandraResourceTest.java</include>-->
-                    </includes>
-                    <excludes>
-                        <exclude>**/CassandraRunnerTest.java</exclude>
-                       <exclude>**/OtherRunnerTest.java</exclude>
-                    </excludes>
-                  </configuration>
-                  <version>2.18</version>
-               </plugin>
+            <!--
+            Need to override parent's surefire plugin here to set system properties.
+           -->
+              <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-surefire-plugin</artifactId>
+                     <configuration>
+                       <systemPropertyVariables>
+                         <storage-config>${basedir}/src/test/conf</storage-config>
+                         <target.directory>${project.build.directory}</target.directory>
+                       </systemPropertyVariables>
+                       <parallel>classes</parallel>
+                       <forkCount>${usergrid.it.forkCount}</forkCount>
+                       <threadCount>${usergrid.it.threads}</threadCount>
+                       <threadCountClasses></threadCountClasses>
+                       <reuseForks>true</reuseForks>
+                       <argLine>-Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8  -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
+                        <includes>
+                           <include>**/CassandraResourceITSuite.java</include>
+                        </includes>
+                        <excludes>
+                            <exclude>**/CassandraRunnerTest.java</exclude>
+                           <exclude>**/OtherRunnerTest.java</exclude>
+                        </excludes>
+                      </configuration>
+                      <version>2.18</version>
+                   </plugin>
 
 
         </plugins>
@@ -271,7 +269,9 @@
 
     </dependencies>
 
-<!--
+    <!--
+    Need jacoco profile here because we override the parent's surefire plugin settings above.
+    -->
     <profiles>
         <profile>
             <id>jacoco</id>
@@ -282,13 +282,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.plugin.version}</version>
                         <configuration>
-                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec</argLine>
+                            <argLine>-Xmx${ug.heapmax} -Xms${ug.heapmin} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec -javaagent:${settings.localRepository}/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar ${ug.argline}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
--->
 
 </project>


### PR DESCRIPTION
With this PR the Jacoco plugin is made optional and will only run when you specify the -Pjacoco argument.  This PR also fixes two problems 1) the Jacoco agent was being specific twice for some modules slowing down the build and 2) we were not invalidating the ShiroCache when an application is restored.

On my machine this saves about 2 minutes of build time (build is 14 minutes without Jacoco and 16 minutes with Jacoco turned on).