### PR TITLE
Add index repair to merge duplicates.

### DIFF
--- a/stack/tools/src/main/java/org/apache/usergrid/tools/DuplicateOrgRepair.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/DuplicateOrgRepair.java
@@ -538,7 +538,7 @@ public class DuplicateOrgRepair extends ToolBase {
             // fix the org name index
             OrganizationInfo orgInfoKeeper = managementService.getOrganizationByUuid( duplicate.getId() );
             try {
-                managementService.updateOrganizationUniqueIndex( orgInfo, duplicate.getId() );
+                managementService.updateOrganizationUniqueIndex( orgInfoKeeper, duplicate.getId() );
                 
             } catch ( Exception e ) {
                 // if there are multiple duplicates this will fail for all but one of them. That's OK

--- a/stack/tools/src/main/java/org/apache/usergrid/tools/DuplicateOrgRepair.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/DuplicateOrgRepair.java
@@ -536,7 +536,7 @@ public class DuplicateOrgRepair extends ToolBase {
             managementService.updateOrganization( orgInfo );
 
             // fix the org name index
-            OrganizationInfo orgInfoKeeper = managementService.getOrganizationByUuid( duplicate.getId() );
+            OrganizationInfo orgInfoKeeper = managementService.getOrganizationByUuid( keeper.getId() );
             try {
                 managementService.updateOrganizationUniqueIndex( orgInfoKeeper, duplicate.getId() );
                 

--- a/stack/tools/src/main/java/org/apache/usergrid/tools/DuplicateOrgRepair.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/DuplicateOrgRepair.java
@@ -529,10 +529,22 @@ public class DuplicateOrgRepair extends ToolBase {
         
         @Override
         public void removeOrg(Org keeper, Org duplicate) throws Exception {
-            // we don't have a remove org API so rename org so that it is no longer a duplicate
+            
+            // rename org so that it is no longer a duplicate
             OrganizationInfo orgInfo = managementService.getOrganizationByUuid( duplicate.getId() );
             orgInfo.setName( "dup_" + keeper.getId() + "_" + RandomStringUtils.randomAlphanumeric(10) );
             managementService.updateOrganization( orgInfo );
+
+            // fix the org name index
+            OrganizationInfo orgInfoKeeper = managementService.getOrganizationByUuid( duplicate.getId() );
+            try {
+                managementService.updateOrganizationUniqueIndex( orgInfo, duplicate.getId() );
+                
+            } catch ( Exception e ) {
+                // if there are multiple duplicates this will fail for all but one of them. That's OK
+                logger.warn("Error repairing unique value keeper {} duplicate {}", 
+                        keeper.getId(), duplicate.getId());
+            }
         }
         
 


### PR DESCRIPTION
Adding in Russo's new updateOrganizationUniqueIndex() to ensure that the keeper organization is the one that is in the unique name index.