### PR TITLE
ElasticsearchException added so we return 503's if we don't do GETs.

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/ElasticsearchExecutionExceptionMapper.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/ElasticsearchExecutionExceptionMapper.java
@@ -1,0 +1,24 @@
+package org.apache.usergrid.rest.exceptions;
+
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+
+
+/**
+ * Created by ApigeeCorporation on 1/19/16.
+ */
+@Provider
+public class ElasticsearchExecutionExceptionMapper
+    extends AbstractExceptionMapper<SearchPhaseExecutionException>  {
+
+    @Override
+    public Response toResponse( SearchPhaseExecutionException spee ){
+        return toResponse( SERVICE_UNAVAILABLE, spee );
+
+    }
+}

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/ElasticsearchExecutionExceptionMapper.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/ElasticsearchExecutionExceptionMapper.java
@@ -9,9 +9,7 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 
-/**
- * Created by ApigeeCorporation on 1/19/16.
- */
+
 @Provider
 public class ElasticsearchExecutionExceptionMapper
     extends AbstractExceptionMapper<SearchPhaseExecutionException>  {


### PR DESCRIPTION
There is a specific error thrown back if elasticsearch cannot search or if the search queue is set to 0. Now it will return 503 service unavailable if we cannot execute the search against elasticsearch