### PR TITLE
Application ID cache should not cache Optionals

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/ApplicationIdCache.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/ApplicationIdCache.java
@@ -35,17 +35,17 @@ public interface ApplicationIdCache {
     /**
      * Evict the application by name
      */
-    public Optional<UUID> getApplicationId(final String applicationName);
+    UUID getApplicationId( final String applicationName );
 
 
     /**
      * Evict the app id by the name
      */
-    public void evictAppId(final String applicationName);
+    void evictAppId( final String applicationName );
 
 
     /**
      * Evict all caches
      */
-    public void evictAll();
+    void evictAll();
 }

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManagerFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManagerFactory.java
@@ -221,7 +221,7 @@ public class CpEntityManagerFactory implements EntityManagerFactory, Application
 
         final UUID appId = applicationIdCache.getApplicationId( appName );
 
-        if ( appId == null ) {
+        if ( appId != null ) {
             throw new ApplicationAlreadyExistsException( name );
         }
 
@@ -259,7 +259,7 @@ public class CpEntityManagerFactory implements EntityManagerFactory, Application
 
         // check for pre-existing application
 
-        if ( lookupApplication( appName ) == null ) {
+        if ( lookupApplication( appName ) != null ) {
             throw new ApplicationAlreadyExistsException( appName );
         }
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManagerFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManagerFactory.java
@@ -31,7 +31,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.apache.commons.lang.StringUtils;
 
 import org.apache.usergrid.corepersistence.asyncevents.AsyncEventService;
-import org.apache.usergrid.corepersistence.index.IndexSchemaCache;
 import org.apache.usergrid.corepersistence.index.IndexSchemaCacheFactory;
 import org.apache.usergrid.corepersistence.index.ReIndexRequestBuilder;
 import org.apache.usergrid.corepersistence.index.ReIndexService;
@@ -220,9 +219,9 @@ public class CpEntityManagerFactory implements EntityManagerFactory, Application
 
         String appName = buildAppName( orgName, name );
 
-        final Optional<UUID> appId = applicationIdCache.getApplicationId( appName );
+        final UUID appId = applicationIdCache.getApplicationId( appName );
 
-        if ( appId.isPresent()) {
+        if ( appId == null ) {
             throw new ApplicationAlreadyExistsException( name );
         }
 
@@ -260,7 +259,7 @@ public class CpEntityManagerFactory implements EntityManagerFactory, Application
 
         // check for pre-existing application
 
-        if ( lookupApplication( appName ).isPresent()) {
+        if ( lookupApplication( appName ) == null ) {
             throw new ApplicationAlreadyExistsException( appName );
         }
 
@@ -451,7 +450,7 @@ public class CpEntityManagerFactory implements EntityManagerFactory, Application
     }
 
 
-    public Optional<UUID> lookupApplication( String orgAppName ) throws Exception {
+    public UUID lookupApplication(String orgAppName ) throws Exception {
         return applicationIdCache.getApplicationId(orgAppName);
     }
 

--- a/stack/core/src/main/java/org/apache/usergrid/persistence/EntityManagerFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/persistence/EntityManagerFactory.java
@@ -20,8 +20,6 @@ package org.apache.usergrid.persistence;
 import java.util.Map;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
-
 import org.apache.usergrid.persistence.core.util.Health;
 import org.apache.usergrid.persistence.index.EntityIndex;
 
@@ -121,7 +119,7 @@ public interface EntityManagerFactory {
      *
      * @throws Exception the exception
      */
-    Optional<UUID> lookupApplication( String name ) throws Exception;
+    UUID lookupApplication(String name ) throws Exception;
 
     /**
      * Returns all the applications in the system.

--- a/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/AsyncEventServiceImplTest.java
+++ b/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/AsyncEventServiceImplTest.java
@@ -20,31 +20,24 @@
 package org.apache.usergrid.corepersistence.index;
 
 
-import org.apache.usergrid.corepersistence.asyncevents.EventBuilder;
-import org.apache.usergrid.persistence.index.EntityIndexFactory;
-import org.apache.usergrid.persistence.index.impl.IndexProducer;
-import org.apache.usergrid.persistence.queue.QueueFig;
-import org.junit.Rule;
-import org.junit.runner.RunWith;
-
+import com.google.inject.Inject;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.usergrid.corepersistence.TestIndexModule;
 import org.apache.usergrid.corepersistence.asyncevents.AsyncEventService;
 import org.apache.usergrid.corepersistence.asyncevents.AsyncEventServiceImpl;
+import org.apache.usergrid.corepersistence.asyncevents.EventBuilder;
 import org.apache.usergrid.persistence.core.aws.NoAWSCredsRule;
 import org.apache.usergrid.persistence.core.metrics.MetricsFactory;
 import org.apache.usergrid.persistence.core.rx.RxTaskScheduler;
 import org.apache.usergrid.persistence.core.test.UseModules;
+import org.apache.usergrid.persistence.index.EntityIndexFactory;
 import org.apache.usergrid.persistence.index.impl.EsRunner;
+import org.apache.usergrid.persistence.index.impl.IndexProducer;
 import org.apache.usergrid.persistence.map.MapManagerFactory;
+import org.apache.usergrid.persistence.queue.QueueFig;
 import org.apache.usergrid.persistence.queue.QueueManagerFactory;
-
-import com.google.inject.Inject;
-
-import net.jcip.annotations.NotThreadSafe;
-
-import static org.apache.usergrid.persistence.core.util.IdGenerator.createId;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
 
 
 @RunWith( EsRunner.class )

--- a/stack/core/src/test/java/org/apache/usergrid/persistence/cassandra/EntityManagerFactoryImplIT.java
+++ b/stack/core/src/test/java/org/apache/usergrid/persistence/cassandra/EntityManagerFactoryImplIT.java
@@ -134,7 +134,7 @@ public class EntityManagerFactoryImplIT extends AbstractCoreIT {
         Entity film2 = em.create( "film", properties2 );
 
         for ( int j=0; j<maxRetries; j++ ) {
-            if ( setup.getEmf().lookupApplication( orgName + "/" + appName ).isPresent()) {
+            if ( setup.getEmf().lookupApplication( orgName + "/" + appName ) != null ) {
                 break;
             }
             Thread.sleep( 500 );
@@ -171,7 +171,7 @@ public class EntityManagerFactoryImplIT extends AbstractCoreIT {
         assertTrue("Deleted app must be found in in deleted apps collection", found);
 
         // attempt to get entities in application's collections in various ways should all fail
-        found =  setup.getEmf().lookupApplication( orgName + "/" + appName ).isPresent() ;
+        found =  setup.getEmf().lookupApplication( orgName + "/" + appName ) != null;
 
         assertFalse("Lookup of deleted app must fail", found);
 
@@ -211,7 +211,7 @@ public class EntityManagerFactoryImplIT extends AbstractCoreIT {
         assertTrue("Restored app not found in apps collection", found);
 
         // TODO: this assertion should work!
-        assertTrue(setup.getEmf().lookupApplication( orgName + "/" + appName ).isPresent());
+        assertTrue(setup.getEmf().lookupApplication( orgName + "/" + appName ) != null );
     }
 
 
@@ -307,7 +307,7 @@ public class EntityManagerFactoryImplIT extends AbstractCoreIT {
 
         UUID appId = setup.createApplication(orgName, appName);
 
-        UUID lookedUpId = setup.getEmf().lookupApplication( orgAppName ).get();
+        UUID lookedUpId = setup.getEmf().lookupApplication( orgAppName );
 
         Assert.assertEquals(appId, lookedUpId);
     }

--- a/stack/mongo-emulator/src/test/java/org/apache/usergrid/mongo/BasicMongoTest.java
+++ b/stack/mongo-emulator/src/test/java/org/apache/usergrid/mongo/BasicMongoTest.java
@@ -110,7 +110,7 @@ public class BasicMongoTest extends AbstractMongoTest {
 
         // check we can find it when using the native entity manager
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Entity entity = em.get( new SimpleEntityRef( (String)returnedObject.get("type"), id ));
@@ -228,7 +228,7 @@ public class BasicMongoTest extends AbstractMongoTest {
 
         Thread.sleep( 5000 );
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Entity entity = em.get( new SimpleEntityRef( (String)returnedObject.get("type"), id ) );
@@ -290,7 +290,7 @@ public class BasicMongoTest extends AbstractMongoTest {
 
         // check it has been deleted
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Entity entity = em.get( new SimpleEntityRef( (String)returnedObject.get("type"), id ) );
@@ -345,7 +345,7 @@ public class BasicMongoTest extends AbstractMongoTest {
         assertFalse( cursor.hasNext() );
 
         // check it has been deleted
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Results results =

--- a/stack/mongo-emulator/src/test/java/org/apache/usergrid/mongo/MongoQueryTest.java
+++ b/stack/mongo-emulator/src/test/java/org/apache/usergrid/mongo/MongoQueryTest.java
@@ -45,7 +45,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void stringEqual() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -105,7 +105,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void greaterThan() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -156,7 +156,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void greaterThanEqual() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -211,7 +211,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void lessThan() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -262,7 +262,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void lessThanEqual() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -317,7 +317,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void in() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -372,7 +372,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void or() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -427,7 +427,7 @@ public class MongoQueryTest extends AbstractMongoTest {
     @Test
     public void and() throws Exception {
 
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();
@@ -476,7 +476,7 @@ public class MongoQueryTest extends AbstractMongoTest {
 
     @Test
     public void withFieldSelector() throws Exception {
-        UUID appId = emf.lookupApplication( "test-organization/test-app" ).get();
+        UUID appId = emf.lookupApplication( "test-organization/test-app" );
         EntityManager em = emf.getEntityManager( appId );
 
         Map<String, Object> properties = new LinkedHashMap<String, Object>();

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/organizations/OrganizationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/organizations/OrganizationResource.java
@@ -138,9 +138,9 @@ public class OrganizationResource extends AbstractContextResource {
         }
 
         String orgAppName = PathingUtils.assembleAppName( organizationName, applicationName );
-        Optional<UUID> optionalAppId = emf.lookupApplication( orgAppName );
+        UUID optionalAppId = emf.lookupApplication( orgAppName );
 
-        if ( !optionalAppId.isPresent()) {
+        if ( optionalAppId == null ) {
 
             // TODO: fix this hacky work-around for apparent Jersey issue
             UUID applicationId = UUIDUtils.tryExtractUUID( applicationName );
@@ -148,11 +148,11 @@ public class OrganizationResource extends AbstractContextResource {
             if ( applicationId == null ) {
                 throw new OrganizationApplicationNotFoundException( orgAppName, uriInfo, properties, management );
             }else{
-                optionalAppId = Optional.fromNullable(applicationId);
+                optionalAppId = applicationId;
             }
         }
 
-        return appResourceFor( optionalAppId.get() );
+        return appResourceFor( optionalAppId );
     }
 
 

--- a/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
@@ -1796,7 +1796,7 @@ public class ManagementServiceImpl implements ManagementService {
             throw new EntityNotFoundException("Deleted application ID " + applicationId + " not found");
         }
 
-        if ( emf.lookupApplication( app.getName() ).isPresent()) {
+        if ( emf.lookupApplication( app.getName() ) != null ) {
             throw new ConflictException("Cannot restore application, one with that name already exists.");
         }
 
@@ -1990,11 +1990,11 @@ public class ManagementServiceImpl implements ManagementService {
         if ( applicationName == null ) {
             return null;
         }
-        Optional<UUID> applicationId = emf.lookupApplication(applicationName);
-        if ( !applicationId.isPresent() ) {
+        UUID applicationId = emf.lookupApplication(applicationName);
+        if ( applicationId == null ) {
             return null;
         }
-        return new ApplicationInfo( applicationId.get(), applicationName.toLowerCase() );
+        return new ApplicationInfo( applicationId, applicationName.toLowerCase() );
     }
 
 

--- a/stack/services/src/test/java/org/apache/usergrid/corepersistence/migration/AppInfoMigrationPluginTest.java
+++ b/stack/services/src/test/java/org/apache/usergrid/corepersistence/migration/AppInfoMigrationPluginTest.java
@@ -202,7 +202,7 @@ public class AppInfoMigrationPluginTest {
         for ( Entity applicationInfo : deletedApps ) {
 
             String appName = applicationInfo.getName();
-            boolean isPresent = setup.getEmf().lookupApplication( appName ).isPresent();
+            boolean isPresent = setup.getEmf().lookupApplication( appName ) != null;
 
             // missing application_info does not completely break applications, but we...
             assertFalse("Should not be able to lookup deleted application by name" + appName, isPresent);
@@ -219,11 +219,11 @@ public class AppInfoMigrationPluginTest {
 
             String appName = orgName + "/application" + i;
 
-            Optional<UUID> uuid = setup.getEmf().lookupApplication(appName);
+            UUID uuid = setup.getEmf().lookupApplication(appName);
 
-            assertTrue ("Should be able to get application", uuid.isPresent() );
+            assertTrue ("Should be able to get application", uuid != null );
 
-            EntityManager em = setup.getEmf().getEntityManager( uuid.get() );
+            EntityManager em = setup.getEmf().getEntityManager( uuid );
 
             Application app = em.getApplication();
             assertEquals( appName, app.getName() );


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/USERGRID-1277

The Application ID cache in CpEntityManagerFactoryImpl caches Optional<UUID> even when o.isPresent() is false. When there is a problem retrieving an application ID from Cassandra and the ID comes back as null, we cache that value and, until the cache entry expires 60 seconds later, the cache returns null for that application and Usergrid throws an NPE, server error 500, etc.
The cache logic should be simplified and we should cache UUIDs and not Optionals.