### PR TITLE
QueueLogging has been changed so that it

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/batch/service/JobSchedulerService.java
+++ b/stack/core/src/main/java/org/apache/usergrid/batch/service/JobSchedulerService.java
@@ -93,7 +93,9 @@ public class JobSchedulerService extends AbstractScheduledService {
         failCounter = metricsFactory.getCounter( JobSchedulerService.class, "scheduler.failed_jobs" );
 
         try {
-            logger.info( "Running one check iteration ..." );
+            if ( logger.isDebugEnabled() ) {
+                logger.debug( "Running one check iteration ..." );
+            }
             List<JobDescriptor> activeJobs;
 
             // run until there are no more active jobs

--- a/stack/core/src/main/java/org/apache/usergrid/mq/cassandra/CassandraMQUtils.java
+++ b/stack/core/src/main/java/org/apache/usergrid/mq/cassandra/CassandraMQUtils.java
@@ -244,7 +244,9 @@ public class CassandraMQUtils {
             queuePath = "/";
         }
 
-        logger.info( "QueueManagerFactoryImpl.getFromQueue: {}", queuePath );
+        if ( logger.isDebugEnabled() ) {
+            logger.debug( "QueueManagerFactoryImpl.getFromQueue: {}", queuePath );
+        }
 
         return Queue.getQueueId( queuePath );
     }


### PR DESCRIPTION
 A: doesn't flood the logs whenever we run a check for a job
B: tell us whenever it drives to get the queued.