### PR TITLE
/org/app/users/me and /users/me related fixes

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/users/UserResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/users/UserResource.java
@@ -117,6 +117,11 @@ public class UserResource extends ServiceResource {
         Map<String, Object> json = mapper.readValue( body, mapTypeReference );
 
         if ( json != null ) {
+
+            if ( "me".equals( json.get("username") ) ) {
+                throw new IllegalArgumentException( "Username 'me' is reserved" );
+            }
+
             json.remove( "password" );
             json.remove( "pin" );
         }
@@ -223,6 +228,10 @@ public class UserResource extends ServiceResource {
 
         if ( json == null ) {
             return null;
+        }
+
+        if ( "me".equals( json.get("username") ) ) {
+            throw new IllegalArgumentException( "Username 'me' is reserved" );
         }
 
         ApiResponse response = createApiResponse();

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/users/UsersResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/users/UsersResource.java
@@ -192,6 +192,10 @@ public class UsersResource extends ServiceResource {
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> json = mapper.readValue( body, mapTypeReference );
 
+        if ( "me".equals( json.get("username") ) ) {
+            throw new IllegalArgumentException( "Username 'me' is reserved" );
+        }
+
         User user = getUser();
         if ( user == null ) {
             return executePost( ui, body, callback );
@@ -233,6 +237,11 @@ public class UsersResource extends ServiceResource {
 
         if ( json instanceof Map ) {
             @SuppressWarnings("unchecked") Map<String, Object> map = ( Map<String, Object> ) json;
+
+            if ( "me".equals( map.get("username") ) ) {
+                throw new IllegalArgumentException( "Username 'me' is reserved" );
+            }
+
             password = ( String ) map.get( "password" );
             map.remove( "password" );
             pin = ( String ) map.get( "pin" );

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UserResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UserResource.java
@@ -111,6 +111,10 @@ public class UserResource extends AbstractContextResource {
         String username = string( json.remove( "username" ) );
         String name = string( json.remove( "name" ) );
 
+        if ( "me".equals( username ) ) {
+            throw new IllegalArgumentException( "Username 'me' is reserved" );
+        }
+
         management.updateAdminUser( user, username, name, email, json );
 
         ApiResponse response = createApiResponse();

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UsersResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UsersResource.java
@@ -127,6 +127,10 @@ public class UsersResource extends AbstractContextResource {
             throw new IllegalArgumentException( "email form parameter is required" );
         }
 
+        if ( "me".equals( username ) ) {
+            throw new IllegalArgumentException( "Username 'me' is reserved" );
+        }
+
         // if username not provided, email will be used
         logger.info( "Create user: {}", (StringUtils.isNotBlank(username) ? username : email) );
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/security/SecuredResourceFilterFactory.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/security/SecuredResourceFilterFactory.java
@@ -409,9 +409,10 @@ public class SecuredResourceFilterFactory implements DynamicFeature {
                 logger.debug( "PathPermissionsFilter.authorize" );
             }
 
-            final String PATH_MSG =
-                "---- Checked permissions for path --------------------------------------------\n" + "Requested path: {} \n"
-                    + "Requested action: {} \n" + "Requested permission: {} \n" + "Permitted: {} \n";
+            final String PATH_MSG = "---- Checked permissions for path --------------------------------------------\n"
+                + "Requested path: {} \n"
+                + "Requested action: {} \n" + "Requested permission: {} \n"
+                + "Permitted: {} \n";
 
             ApplicationInfo application = null;
 
@@ -449,6 +450,12 @@ public class SecuredResourceFilterFactory implements DynamicFeature {
                 String path = request.getUriInfo().getPath().toLowerCase().replace(applicationName, "");
                 String perm =  getPermissionFromPath( em.getApplicationRef().getUuid(), operation, path );
 
+                if ( "/users/me".equals( path ) ) {
+                    // shortcut the permissions checking, the "me" end-point is always allowed
+                    logger.debug("Allowing {} access to /users/me", getSubject().toString() );
+                    return;
+                }
+
                 boolean permitted = currentUser.isPermitted( perm );
                 if ( logger.isDebugEnabled() ) {
                     logger.debug( PATH_MSG, path, operation, perm, permitted );
@@ -461,7 +468,6 @@ public class SecuredResourceFilterFactory implements DynamicFeature {
                     logger.debug("Checked subject {} for perm {}", subject != null ? subject.toString() : "", perm);
                     logger.debug("------------------------------------------------------------------------------");
                 }
-
 
             } catch (Exception e){
                 throw mappableSecurityException( "unauthorized",

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/security/SecuredResourceFilterFactory.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/security/SecuredResourceFilterFactory.java
@@ -450,7 +450,7 @@ public class SecuredResourceFilterFactory implements DynamicFeature {
                 String path = request.getUriInfo().getPath().toLowerCase().replace(applicationName, "");
                 String perm =  getPermissionFromPath( em.getApplicationRef().getUuid(), operation, path );
 
-                if ( "/users/me".equals( path ) ) {
+                if ( "/users/me".equals( path ) && request.getMethod().equalsIgnoreCase( "get" )) {
                     // shortcut the permissions checking, the "me" end-point is always allowed
                     logger.debug("Allowing {} access to /users/me", getSubject().toString() );
                     return;

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/applications/SecurityIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/applications/SecurityIT.java
@@ -17,7 +17,6 @@
 package org.apache.usergrid.rest.applications;
 
 
-import com.sun.jersey.api.client.UniformInterfaceException;
 import org.apache.usergrid.rest.test.resource.AbstractRestIT;
 import org.apache.usergrid.rest.test.resource.model.ApiResponse;
 import org.apache.usergrid.utils.UUIDUtils;

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/test/resource/endpoints/NamedResource.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/test/resource/endpoints/NamedResource.java
@@ -283,7 +283,7 @@ public class NamedResource implements UrlResource {
 
         if (useBasicAuthentication) {
             HttpAuthenticationFeature feature = HttpAuthenticationFeature.basicBuilder()
-                                                                         .credentials("superuser", "superpassword").build();
+                .credentials("superuser", "superpassword").build();
             return resource.register(feature).request()
                            .accept(MediaType.APPLICATION_JSON)
                            .post(javax.ws.rs.client.Entity.json(entity), gt);
@@ -341,6 +341,12 @@ public class NamedResource implements UrlResource {
         WebTarget resource = getTarget(useToken);
         return resource.request().put(
             javax.ws.rs.client.Entity.entity(data, type), ApiResponse.class);
+    }
+
+    public ApiResponse put(boolean useToken, org.apache.usergrid.rest.test.resource.model.Entity entity ) {
+        WebTarget resource = getTarget(useToken);
+        return resource.request().put(
+            javax.ws.rs.client.Entity.entity(entity, MediaType.APPLICATION_JSON_TYPE), ApiResponse.class);
     }
 
     public ApiResponse put(byte[] data, MediaType type) {

--- a/stack/services/src/main/java/org/apache/usergrid/security/shiro/principals/ApplicationUserPrincipal.java
+++ b/stack/services/src/main/java/org/apache/usergrid/security/shiro/principals/ApplicationUserPrincipal.java
@@ -33,12 +33,14 @@ import org.apache.usergrid.persistence.entities.User;
 import org.apache.usergrid.security.shiro.Realm;
 import org.apache.usergrid.security.shiro.UsergridAuthorizationInfo;
 import org.apache.usergrid.security.shiro.credentials.AccessTokenCredentials;
+import org.apache.usergrid.security.shiro.utils.SubjectUtils;
 import org.apache.usergrid.security.tokens.TokenInfo;
 import org.apache.usergrid.security.tokens.TokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.usergrid.security.shiro.utils.SubjectUtils.getPermissionFromPath;
+import static org.apache.usergrid.security.shiro.utils.SubjectUtils.getSubject;
 
 
 public class ApplicationUserPrincipal extends UserPrincipal {
@@ -94,13 +96,10 @@ public class ApplicationUserPrincipal extends UserPrincipal {
 
         grant( info, getPermissionFromPath( applicationId, "access" ) );
 
-                /*
-                 * grant(info, principal, getPermissionFromPath(applicationId,
-                 * "get,put,post,delete", "/users/${user}",
-                 * "/users/${user}/feed", "/users/${user}/activities",
-                 * "/users/${user}/groups", "/users/${user}/following/*",
-                 * "/users/${user}/following/user/*"));
-                 */
+        if ( SubjectUtils.getUser() != null ) {
+            // ensure that the /org/app/users/me end-point always works for logged in user
+            grant( info, "applications:get:" + applicationId + ":/users/" + SubjectUtils.getUser().getUuid() );
+        }
 
         EntityManager em = emf.getEntityManager( applicationId );
         try {


### PR DESCRIPTION
Ensure that /org/app/users/me always works for logged in user, regardless of roles/permissions, also that it is impossible to create an app or admin user named 'me' (via post or put)