### PR TITLE
Support for nested fields in Query Select Mappings

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
@@ -52,9 +52,9 @@ import rx.Observable;
 
 
 /**
- * Loads entities from an incoming CandidateResult emissions into entities, then streams them on
- * performs internal buffering for efficiency.  Note that all entities may not be emitted if our load crosses page boundaries.  It is up to the
- * collector to determine when to stop streaming entities.
+ * Loads entities from an incoming CandidateResult emissions into entities, then streams them on performs internal
+ * buffering for efficiency.  Note that all entities may not be emitted if our load crosses page boundaries.
+ * It is up to the collector to determine when to stop streaming entities.
  */
 public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate>, FilterResult<Entity>> {
 
@@ -93,11 +93,12 @@ public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate
             entityCollectionManagerFactory.createCollectionManager( applicationScope );
 
 
-        final EntityIndex applicationIndex =
-            entityIndexFactory.createEntityIndex(indexLocationStrategyFactory.getIndexLocationStrategy(applicationScope) );
+        final EntityIndex applicationIndex = entityIndexFactory
+            .createEntityIndex(indexLocationStrategyFactory.getIndexLocationStrategy(applicationScope) );
 
         //buffer them to get a page size we can make 1 network hop
-        final Observable<FilterResult<Entity>> searchIdSetObservable = candidateResultsObservable.buffer( pipelineContext.getLimit() )
+        final Observable<FilterResult<Entity>> searchIdSetObservable =
+            candidateResultsObservable.buffer( pipelineContext.getLimit() )
 
             //load them
             .flatMap( candidateResults -> {
@@ -198,7 +199,8 @@ public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate
 
 
     /**
-     * Our collector to collect entities.  Not quite a true collector, but works within our operational flow as this state is mutable and difficult to represent functionally
+     * Our collector to collect entities.  Not quite a true collector, but works within our operational
+     * flow as this state is mutable and difficult to represent functionally
      */
     private static final class EntityVerifier {
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
@@ -163,17 +163,19 @@ public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate
 
     private void nestedFieldSet( Map<String, Field> result, String[] parts, Map<String, Field> fieldMap) {
         if ( parts.length > 0 ) {
+
             if ( fieldMap.containsKey( parts[0] )) {
                 Field field = fieldMap.get( parts[0] );
                 if ( field instanceof EntityObjectField ) {
                     EntityObjectField eof = (EntityObjectField)field;
-                    if ( result.get( parts[0] ) == null ) {
-                        result.put( parts[0], new EntityObjectField( parts[0], new EntityObject() ) );
-                    }
+                    result.putIfAbsent( parts[0], new EntityObjectField( parts[0], new EntityObject() ) );
+
+                    // recursion
                     nestedFieldSet(
                         ((EntityObjectField)result.get( parts[0] )).getValue().getFieldMap(),
                         Arrays.copyOfRange(parts, 1, parts.length),
                         eof.getValue().getFieldMap());
+
                 } else {
                     result.put( parts[0], field );
                 }
@@ -184,11 +186,15 @@ public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate
 
     private boolean nestedFieldCheck( String[] parts, Map<String, Field> fieldMap) {
         if ( parts.length > 0 ) {
+
             if ( fieldMap.containsKey( parts[0] )) {
                 Field field = fieldMap.get( parts[0] );
                 if ( field instanceof EntityObjectField ) {
                     EntityObjectField eof = (EntityObjectField)field;
+
+                    // recursion
                     return nestedFieldCheck( Arrays.copyOfRange(parts, 1, parts.length), eof.getValue().getFieldMap());
+
                 } else {
                     return true;
                 }

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
@@ -161,6 +161,13 @@ public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate
     }
 
 
+    /**
+     * Sets field in result map with support for nested fields via recursion.
+     *
+     * @param result The result map of filtered fields
+     * @param parts The parts of the field name (more than one if field is nested)
+     * @param fieldMap Map of fields of the object
+     */
     private void nestedFieldSet( Map<String, Field> result, String[] parts, Map<String, Field> fieldMap) {
         if ( parts.length > 0 ) {
 
@@ -184,6 +191,12 @@ public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate
     }
 
 
+    /**
+     * Check to see if field should be included in filtered result with support for nested fields via recursion.
+     *
+     * @param parts The parts of the field name (more than one if field is nested)
+     * @param fieldMap Map of fields of the object
+     */
     private boolean nestedFieldCheck( String[] parts, Map<String, Field> fieldMap) {
         if ( parts.length > 0 ) {
 

--- a/stack/core/src/test/java/org/apache/usergrid/persistence/IndexIT.java
+++ b/stack/core/src/test/java/org/apache/usergrid/persistence/IndexIT.java
@@ -476,6 +476,7 @@ public class IndexIT extends AbstractCoreIT {
             put("data", new HashMap() {{
                 put("xfactor", 5.1);
                 put("rando", "bar");
+                put("mondo", "2000");
             }});
         }};
         em.create("names", entity1);
@@ -486,6 +487,7 @@ public class IndexIT extends AbstractCoreIT {
             put("data", new HashMap() {{
                 put("xfactor", 5.1);
                 put("rando", "bar");
+                put("mondo", "2001");
             }});
         }};
         em.create("names", entity2);
@@ -518,7 +520,7 @@ public class IndexIT extends AbstractCoreIT {
 
         {
             //  query for only one bogus field name should return empty entities
-            Query query = Query.fromQL( "select data.rando where status = 'pickled'" );
+            Query query = Query.fromQL( "select data.rando,data.mondo where status = 'pickled'" );
             Results r = em.searchCollection( em.getApplicationRef(), "names", query );
             assertTrue( r.getEntities() != null && r.getEntities().size() == 2 );
 
@@ -526,6 +528,7 @@ public class IndexIT extends AbstractCoreIT {
 
             assertNotNull( first.getProperty("data") );
             assertEquals( ((Map<String, Object>)first.getProperty("data")).get("rando"), "bar" );
+            assertEquals( ((Map<String, Object>)first.getProperty("data")).get("mondo"), "2001" );
 
             assertTrue( first.getDynamicProperties().size() == 2 );
         }

--- a/stack/core/src/test/java/org/apache/usergrid/persistence/IndexIT.java
+++ b/stack/core/src/test/java/org/apache/usergrid/persistence/IndexIT.java
@@ -528,7 +528,7 @@ public class IndexIT extends AbstractCoreIT {
             assertTrue( first.getDynamicProperties().size() == 3 );
         }
 
-        // multiple nested fields with one doubly-nesed field
+        // multiple nested fields with one doubly-nested field
         {
             Query query = Query.fromQL( "select data.rando, data.mondo, data.misc.range where status = 'pickled'" );
             Results r = em.searchCollection( em.getApplicationRef(), "names", query );

--- a/stack/core/src/test/java/org/apache/usergrid/persistence/IndexIT.java
+++ b/stack/core/src/test/java/org/apache/usergrid/persistence/IndexIT.java
@@ -17,6 +17,7 @@
 package org.apache.usergrid.persistence;
 
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -461,4 +462,83 @@ public class IndexIT extends AbstractCoreIT {
 
 
     }
+
+    @Test
+    public void testSelectMappings() throws Exception {
+
+        UUID applicationId = app.getId();
+
+        EntityManager em = setup.getEmf().getEntityManager(applicationId);
+
+        Map<String, Object> entity1 = new HashMap<String, Object>() {{
+            put("name","name_1");
+            put("status", "pickled");
+            put("data", new HashMap() {{
+                put("xfactor", 5.1);
+                put("rando", "bar");
+            }});
+        }};
+        em.create("names", entity1);
+
+        Map<String, Object> entity2 = new HashMap<String, Object>() {{
+            put("name","name_2");
+            put("status", "pickled");
+            put("data", new HashMap() {{
+                put("xfactor", 5.1);
+                put("rando", "bar");
+            }});
+        }};
+        em.create("names", entity2);
+
+        app.refreshIndex();
+
+        {
+            Query query = Query.fromQL("select status where status = 'pickled'");
+            Results r = em.searchCollection( em.getApplicationRef(), "names", query );
+            assertTrue(r.getEntities() != null && r.getEntities().size() == 2);
+            Entity first =  r.getEntities().get(0);
+            assertTrue(first.getDynamicProperties().size() == 2);
+        }
+
+        {
+            Query query = Query.fromQL( "select status, data.rando where data.rando = 'bar'" );
+            Results r = em.searchCollection( em.getApplicationRef(), "names", query );
+            assertTrue( r.getEntities() != null && r.getEntities().size() == 2 );
+
+            Entity first = r.getEntities().get( 0 );
+
+            assertNotNull( first.getProperty("status") );
+            assertEquals( first.getProperty("status"), "pickled" );
+
+            assertNotNull( first.getProperty("data") );
+            assertEquals( ((Map<String, Object>)first.getProperty("data")).get("rando"), "bar" );
+
+            assertTrue( first.getDynamicProperties().size() == 3 );
+        }
+
+        {
+            //  query for only one bogus field name should return empty entities
+            Query query = Query.fromQL( "select data.rando where status = 'pickled'" );
+            Results r = em.searchCollection( em.getApplicationRef(), "names", query );
+            assertTrue( r.getEntities() != null && r.getEntities().size() == 2 );
+
+            Entity first = r.getEntities().get( 0 );
+
+            assertNotNull( first.getProperty("data") );
+            assertEquals( ((Map<String, Object>)first.getProperty("data")).get("rando"), "bar" );
+
+            assertTrue( first.getDynamicProperties().size() == 2 );
+        }
+
+        {
+            //  query for only one bogus field name should return empty entities
+            Query query = Query.fromQL( "select data.bogusfieldname where status = 'pickled'" );
+            Results r = em.searchCollection( em.getApplicationRef(), "names", query );
+            assertTrue( r.getEntities() != null && r.getEntities().size() == 2 );
+            Entity first = r.getEntities().get( 0 );
+            assertTrue( first.getDynamicProperties().size() == 1 );
+        }
+
+    }
+
 }

--- a/stack/corepersistence/model/src/main/java/org/apache/usergrid/persistence/model/field/value/EntityObject.java
+++ b/stack/corepersistence/model/src/main/java/org/apache/usergrid/persistence/model/field/value/EntityObject.java
@@ -19,10 +19,7 @@
 package org.apache.usergrid.persistence.model.field.value;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.usergrid.persistence.model.field.Field;
 
@@ -41,11 +38,19 @@ public class EntityObject implements Serializable {
     @JsonIgnore
     private long size;
 
+    // field names are treated in case-insensitive way by design
+    static class CaseInsensitiveComparator implements Comparator<String> {
+        public int compare(String o1, String o2) {
+            return o1.compareToIgnoreCase(o2);
+        }
+    }
+    public static final CaseInsensitiveComparator INSTANCE = new CaseInsensitiveComparator();
+
     /**
      * Fields the users can set
      */
     @JsonTypeInfo( use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="@class" )
-    private final Map<String, Field> fields = new HashMap<String, Field>();
+    private Map<String, Field> fields = new TreeMap<String, Field>(INSTANCE);
 
     /**
      * Add the field, return the old one if it existed

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/applications/queries/SelectMappingsQueryTest.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/applications/queries/SelectMappingsQueryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.usergrid.rest.applications.queries;
+
+import org.apache.usergrid.rest.test.resource.model.Collection;
+import org.apache.usergrid.rest.test.resource.model.Entity;
+import org.apache.usergrid.rest.test.resource.model.QueryParameters;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+public class SelectMappingsQueryTest extends QueryTestBase {
+    private static final Logger logger = LoggerFactory.getLogger(OrderByTest.class);
+
+
+    @Test
+    public void testNestedSelectFieldNames() throws Exception {
+
+        generateTestEntities(20, "things");
+
+        QueryParameters params = new QueryParameters()
+            .setQuery("select actor.displayName,sometestprop where sometestprop = 'testprop'");
+        Collection things = this.app().collection("things").get(params);
+        assertEquals( 10, things.getNumOfEntities() );
+
+        Iterator<Entity> iter = things.iterator();
+        while ( iter.hasNext() ) {
+
+            Entity entity = iter.next();
+            assertEquals( 5, entity.getDynamicProperties().size() );
+
+            assertNotNull( entity.getDynamicProperties().get("uuid") );
+            assertNotNull( entity.getDynamicProperties().get("type") );
+            assertNotNull( entity.getDynamicProperties().get("metadata") );
+            assertNotNull( entity.getDynamicProperties().get("sometestprop") );
+
+            Map<String, Object> actor = (Map<String, Object>)entity.getDynamicProperties().get("actor");
+            assertNotNull( actor );
+            assertNotNull( actor.get("displayName") );
+
+        }
+    }
+
+
+    /**
+     * Shows that field names are case-insensitive.
+     * If you define two fields with same name but different cases, behavior is undefined.
+     */
+    @Test
+    public void testFieldNameCaseSensitivity() throws Exception {
+
+        int numberOfEntities = 10;
+        String collectionName = "things";
+
+        Entity[] entities = new Entity[numberOfEntities];
+        Entity props = new Entity();
+
+        for (int i = 0; i < numberOfEntities; i++) {
+            props.put("testProp", "a");
+            props.put("testprop", "b");
+            entities[i] = app().collection(collectionName).post(props);
+        }
+        refreshIndex();
+
+        {
+            QueryParameters params = new QueryParameters()
+                .setQuery( "select * where testProp = 'b'" );
+            Collection things = this.app().collection( "things" ).get( params );
+
+            // if field names were case sensitive, this would fail
+            assertEquals( numberOfEntities, things.getNumOfEntities() );
+        }
+
+        {
+            QueryParameters params = new QueryParameters()
+                .setQuery( "select * where testprop='b'" );
+            Collection things = this.app().collection( "things" ).get( params );
+
+            assertEquals( numberOfEntities, things.getNumOfEntities() );
+        }
+
+    }
+
+}

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/applications/queries/SelectMappingsQueryTest.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/applications/queries/SelectMappingsQueryTest.java
@@ -103,7 +103,7 @@ public class SelectMappingsQueryTest extends QueryTestBase {
      * Field named testProp can be over-written by field named TESTPROP.
      */
     @Test
-    public void testFieldOverride() throws Exception {
+    public void testFieldOverride1() throws Exception {
 
         String collectionName = "things";
 
@@ -119,7 +119,7 @@ public class SelectMappingsQueryTest extends QueryTestBase {
         app().collection( collectionName ).post( entity );
         refreshIndex();
 
-        // testProp and TESTPROP should now have newValue
+        // testProp and TESTPROP should new be queryable by new value
 
         QueryParameters params = new QueryParameters()
             .setQuery( "select * where testProp='" + newValue + "'" );
@@ -131,4 +131,38 @@ public class SelectMappingsQueryTest extends QueryTestBase {
         things = app().collection( "things" ).get( params );
         assertEquals( 1, things.getNumOfEntities() );
     }
+
+    /**
+     * Field named testProp can be over-written by field named TESTPROP.
+     */
+    @Test
+    public void testFieldOverride2() throws Exception {
+
+        String collectionName = "things";
+
+        // create entity with TESTPROP=value
+        String value = RandomStringUtils.randomAlphabetic( 20 );
+        Entity entity = new Entity().withProp( "TESTPROP", value );
+        app().collection( collectionName ).post( entity );
+        refreshIndex();
+
+        // override with testProp=newValue
+        String newValue = RandomStringUtils.randomAlphabetic( 20 );
+        entity = new Entity().withProp( "testProp", newValue );
+        app().collection( collectionName ).post( entity );
+        refreshIndex();
+
+        // testProp and TESTPROP should new be queryable by new value
+
+        QueryParameters params = new QueryParameters()
+            .setQuery( "select * where testProp='" + newValue + "'" );
+        Collection things = this.app().collection( "things" ).get( params );
+        assertEquals( 1, things.getNumOfEntities() );
+
+        params = new QueryParameters()
+            .setQuery( "select * where TESTPROP='" + newValue + "'" );
+        things = app().collection( "things" ).get( params );
+        assertEquals( 1, things.getNumOfEntities() );
+    }
+
 }


### PR DESCRIPTION
In Usergrid 2 the JSON data format returned for Queries with Select Mappings changed from an array of field values to an array of Entities, each with only the selected fields (plus normal UUID, type and metadata fields).

This PR adds support for nested fields in Queries with Select Mappings, and ensures that field names are preserved as-is but treated in a case-insensitive way.

