### PR TITLE
Improvements to management app / startup logic

### DIFF
--- a/stack/config/src/main/resources/usergrid-default.properties
+++ b/stack/config/src/main/resources/usergrid-default.properties
@@ -195,13 +195,6 @@ cassandra.lock.writecl=LOCAL_QUORUM
 #
 #cassandra.useSocketKeepalive=false
 
-# Number of times to retry creation of lock keyspace and column family
-cassandra.lock.init.retries = 100;
-
-# Interval between lock keyspace creation attempts (in milliseconds)
-cassandra.lock.init.interval = 1000;
-
-
 ##################### Async Threadpool Settings #####################
 
 # Set the number of threads available in the Rx Async Thread Pool

--- a/stack/config/src/main/resources/usergrid-default.properties
+++ b/stack/config/src/main/resources/usergrid-default.properties
@@ -195,6 +195,12 @@ cassandra.lock.writecl=LOCAL_QUORUM
 #
 #cassandra.useSocketKeepalive=false
 
+# Number of times to retry creation of lock keyspace and column family
+cassandra.lock.init.retries = 100;
+
+# Interval between lock keyspace creation attempts (in milliseconds)
+cassandra.lock.init.interval = 1000;
+
 
 ##################### Async Threadpool Settings #####################
 
@@ -628,6 +634,8 @@ usergrid.auth.cache.inmemory.size=3000
 # all (= in + out)'
 usergrid.rest.default-connection-param=all
 
+# Number of times to retry attempt to access management app on startup
+management.app.max.retries=100
 
 
 ##############################  Usergrid Testing  #############################

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
@@ -36,7 +36,6 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.apache.usergrid.persistence.*;
 import org.apache.usergrid.persistence.collection.EntitySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +48,24 @@ import org.apache.usergrid.corepersistence.service.CollectionService;
 import org.apache.usergrid.corepersistence.service.ConnectionService;
 import org.apache.usergrid.corepersistence.util.CpEntityMapUtils;
 import org.apache.usergrid.corepersistence.util.CpNamingUtils;
+import org.apache.usergrid.persistence.AggregateCounter;
+import org.apache.usergrid.persistence.AggregateCounterSet;
+import org.apache.usergrid.persistence.CollectionRef;
+import org.apache.usergrid.persistence.ConnectedEntityRef;
+import org.apache.usergrid.persistence.ConnectionRef;
+import org.apache.usergrid.persistence.Entity;
+import org.apache.usergrid.persistence.EntityFactory;
+import org.apache.usergrid.persistence.EntityManager;
+import org.apache.usergrid.persistence.EntityRef;
+import org.apache.usergrid.persistence.IndexBucketLocator;
+import org.apache.usergrid.persistence.Query;
 import org.apache.usergrid.persistence.Query.Level;
+import org.apache.usergrid.persistence.RelationManager;
+import org.apache.usergrid.persistence.Results;
+import org.apache.usergrid.persistence.Schema;
+import org.apache.usergrid.persistence.SimpleEntityRef;
+import org.apache.usergrid.persistence.SimpleRoleRef;
+import org.apache.usergrid.persistence.TypedEntity;
 import org.apache.usergrid.persistence.cassandra.ApplicationCF;
 import org.apache.usergrid.persistence.cassandra.CassandraPersistenceUtils;
 import org.apache.usergrid.persistence.cassandra.CassandraService;
@@ -214,9 +230,6 @@ public class CpEntityManager implements EntityManager {
 
     private EntityCollectionManager ecm;
 
-    private CpEntityManagerFactory emf;
-
-
     //    /** Short-term cache to keep us from reloading same Entity during single request. */
 //    private LoadingCache<EntityScope, org.apache.usergrid.persistence.model.entity.Entity> entityCache;
 
@@ -229,8 +242,7 @@ public class CpEntityManager implements EntityManager {
      * @param metricsFactory
      * @param applicationId
      */
-    public CpEntityManager(final CpEntityManagerFactory emf,
-                           final CassandraService cass,
+    public CpEntityManager( final CassandraService cass,
                            final CounterUtils counterUtils,
                            final AsyncEventService indexService,
                            final ManagerCache managerCache,
@@ -242,7 +254,6 @@ public class CpEntityManager implements EntityManager {
                            final IndexSchemaCacheFactory indexSchemaCacheFactory,
                            final UUID applicationId ) {
 
-        this.emf = emf;
         this.entityManagerFig = entityManagerFig;
 
         Preconditions.checkNotNull( cass, "cass must not be null" );
@@ -258,6 +269,8 @@ public class CpEntityManager implements EntityManager {
         this.graphManagerFactory = graphManagerFactory;
         this.connectionService = connectionService;
         this.collectionService = collectionService;
+
+
 
         this.managerCache = managerCache;
         this.applicationId = applicationId;

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
@@ -243,16 +243,16 @@ public class CpEntityManager implements EntityManager {
      * @param applicationId
      */
     public CpEntityManager( final CassandraService cass,
-                           final CounterUtils counterUtils,
-                           final AsyncEventService indexService,
-                           final ManagerCache managerCache,
-                           final MetricsFactory metricsFactory,
-                           final EntityManagerFig entityManagerFig,
-                           final GraphManagerFactory graphManagerFactory,
-                           final CollectionService collectionService,
-                           final ConnectionService connectionService,
-                           final IndexSchemaCacheFactory indexSchemaCacheFactory,
-                           final UUID applicationId ) {
+                            final CounterUtils counterUtils,
+                            final AsyncEventService indexService,
+                            final ManagerCache managerCache,
+                            final MetricsFactory metricsFactory,
+                            final EntityManagerFig entityManagerFig,
+                            final GraphManagerFactory graphManagerFactory,
+                            final CollectionService collectionService,
+                            final ConnectionService connectionService,
+                            final IndexSchemaCacheFactory indexSchemaCacheFactory,
+                            final UUID applicationId ) {
 
         this.entityManagerFig = entityManagerFig;
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManagerFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManagerFactory.java
@@ -174,17 +174,17 @@ public class CpEntityManagerFactory implements EntityManagerFactory, Application
         int maxRetries = 1000;
         int retries = 0;
         boolean managementAppFound = false;
-        Set<Class> seenBefore = new HashSet<>(100);
         while ( !managementAppFound && retries++ < maxRetries ) {
             try {
                 getEntityManager( getManagementAppId() ).getApplication();
                 managementAppFound = true;
 
             } catch ( Throwable t ) {
-                if ( seenBefore.contains( t.getClass() )) { // don't log full stack trace if we've seen same before
-                    logger.error("Error {} getting management app on try {}", t.getClass().getSimpleName(), retries);
+                String msg = "Error " + t.getClass() + " getting management app on try " + retries;
+                if ( logger.isDebugEnabled() ) {
+                    logger.error( msg, t);
                 } else {
-                    logger.error("Error getting management app on try {}", t.getClass().getSimpleName(), t);
+                    logger.error(msg);
                 }
             }
         }

--- a/stack/core/src/main/java/org/apache/usergrid/locking/LockManager.java
+++ b/stack/core/src/main/java/org/apache/usergrid/locking/LockManager.java
@@ -38,4 +38,9 @@ public interface LockManager {
      * @throws UGLockException if the lock cannot be acquired
      */
     public Lock createLock( final UUID applicationId, final String... path );
+
+    /**
+     * Setup lock persistence mechanism.
+     */
+    public void setup();
 }

--- a/stack/core/src/main/java/org/apache/usergrid/locking/cassandra/AstyanaxLockManagerImpl.java
+++ b/stack/core/src/main/java/org/apache/usergrid/locking/cassandra/AstyanaxLockManagerImpl.java
@@ -52,6 +52,7 @@ public class AstyanaxLockManagerImpl implements LockManager {
     private ColumnFamily columnFamily;
     private static final int MINIMUM_LOCK_EXPIRATION = 60000; // 1 minute
 
+
     @Inject
     public AstyanaxLockManagerImpl(CassandraFig cassandraFig,
                                    CassandraCluster cassandraCluster ) throws ConnectionException {
@@ -59,7 +60,7 @@ public class AstyanaxLockManagerImpl implements LockManager {
         this.cassandraFig = cassandraFig;
 
         // hold up construction until we can create the column family
-        int maxRetries = 1000;
+        int maxRetries = cassandraFig.getLockManagerInitRetries();
         int retries = 0;
         boolean famReady = false;
         while ( !famReady && retries++ < maxRetries ) {
@@ -76,7 +77,7 @@ public class AstyanaxLockManagerImpl implements LockManager {
                 } else {
                     logger.error( msg );
                 }
-                try { Thread.sleep(1000); } catch (InterruptedException ignored) {}
+                try { Thread.sleep( cassandraFig.getLockManagerInitInterval() ); } catch (InterruptedException ignored) {}
             }
         }
 

--- a/stack/core/src/main/java/org/apache/usergrid/locking/noop/NoOpLockManagerImpl.java
+++ b/stack/core/src/main/java/org/apache/usergrid/locking/noop/NoOpLockManagerImpl.java
@@ -38,4 +38,9 @@ public class NoOpLockManagerImpl implements LockManager {
     public Lock createLock( UUID applicationId, String... path ) {
         return new NoOpLockImpl();
     }
+
+    @Override
+    public void setup() {
+        // no op
+    }
 }

--- a/stack/corepersistence/collection/src/main/java/org/apache/usergrid/persistence/collection/exception/CollectionRuntimeException.java
+++ b/stack/corepersistence/collection/src/main/java/org/apache/usergrid/persistence/collection/exception/CollectionRuntimeException.java
@@ -17,6 +17,7 @@
  */
 package org.apache.usergrid.persistence.collection.exception;
 
+import com.netflix.astyanax.connectionpool.exceptions.BadRequestException;
 import org.apache.usergrid.persistence.collection.MvccEntity;
 import org.apache.usergrid.persistence.core.scope.ApplicationScope;
 
@@ -56,6 +57,16 @@ public class CollectionRuntimeException extends RuntimeException {
         this.applicationScope = scope;
     }
 
+    public boolean isMissingKeyspace() {
+        if ( getCause() instanceof BadRequestException ) {
+            BadRequestException bre = (BadRequestException)getCause();
+            String msg = bre.getMessage();
+            if ( msg.contains("Keyspace") && msg.contains( "does not exist" ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public ApplicationScope getApplicationScope() {
         return applicationScope;

--- a/stack/corepersistence/collection/src/main/java/org/apache/usergrid/persistence/collection/exception/CollectionRuntimeException.java
+++ b/stack/corepersistence/collection/src/main/java/org/apache/usergrid/persistence/collection/exception/CollectionRuntimeException.java
@@ -57,7 +57,7 @@ public class CollectionRuntimeException extends RuntimeException {
         this.applicationScope = scope;
     }
 
-    public boolean isMissingKeyspace() {
+    public boolean isBootstrapping() {
         if ( getCause() instanceof BadRequestException ) {
             BadRequestException bre = (BadRequestException)getCause();
             String msg = bre.getMessage();

--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/astyanax/CassandraCluster.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/astyanax/CassandraCluster.java
@@ -1,14 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.usergrid.persistence.core.astyanax;
 
-
-
 import com.netflix.astyanax.Keyspace;
-
 import java.util.Map;
 
-
 public interface CassandraCluster {
-
 
     Map<String, Keyspace> getKeyspaces();
 

--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/astyanax/CassandraFig.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/astyanax/CassandraFig.java
@@ -50,8 +50,8 @@ public interface CassandraFig extends GuicyFig {
     String LOCKS_CONNECTIONS = "cassandra.lock.connections";
     String LOCKS_EXPIRATION = "cassandra.lock.expiration.milliseconds";
 
-
-
+    String LOCK_MANAGER_INIT_RETRIES = "cassandra.lock.init.retries";
+    String LOCK_MANAGER_INIT_INTERVAL = "cassandra.lock.init.interval";
 
     // re-usable default values
     String DEFAULT_CONNECTION_POOLSIZE = "15";
@@ -179,5 +179,19 @@ public interface CassandraFig extends GuicyFig {
     @Key( LOCKS_EXPIRATION )
     @Default(DEFAULT_LOCKS_EXPIRATION)
     int getLocksExpiration();
+
+    /**
+     * How many times to attempt lock keyspace and column family creation
+     */
+    @Key( LOCK_MANAGER_INIT_RETRIES )
+    @Default( "100" )
+    int getLockManagerInitRetries();
+
+    /**
+     * Return the expiration that should be used for expiring a lock if it's not released
+     */
+    @Key( LOCK_MANAGER_INIT_INTERVAL )
+    @Default( "1000" )
+    int getLockManagerInitInterval();
 
 }

--- a/stack/services/src/main/java/org/apache/usergrid/services/ServiceManager.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/ServiceManager.java
@@ -96,6 +96,14 @@ public class ServiceManager {
         this.qm = qm;
         this.properties = properties;
 
+        // additional logging to help debug https://issues.apache.org/jira/browse/USERGRID-1291
+        if ( em == null ) {
+            logger.error("EntityManager is null");
+        }
+        if ( qm == null ) {
+            logger.error("QueueManager is null");
+        }
+
         if ( em != null ) {
             try {
                 application = em.getApplication();

--- a/stack/services/src/main/java/org/apache/usergrid/services/ServiceManager.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/ServiceManager.java
@@ -17,29 +17,32 @@
 package org.apache.usergrid.services;
 
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import org.apache.commons.lang.StringUtils;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
 import org.apache.usergrid.batch.service.SchedulerService;
 import org.apache.usergrid.locking.LockManager;
 import org.apache.usergrid.mq.QueueManager;
 import org.apache.usergrid.persistence.Entity;
 import org.apache.usergrid.persistence.EntityManager;
 import org.apache.usergrid.persistence.EntityRef;
+import org.apache.usergrid.persistence.cassandra.CassandraService;
 import org.apache.usergrid.persistence.entities.Application;
 import org.apache.usergrid.services.ServiceParameter.IdParameter;
 import org.apache.usergrid.services.applications.ApplicationsService;
 import org.apache.usergrid.services.exceptions.UndefinedServiceEntityTypeException;
 import org.apache.usergrid.utils.ListUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.StringUtils;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 import static org.apache.usergrid.persistence.SimpleEntityRef.ref;
 import static org.apache.usergrid.utils.InflectionUtils.pluralize;

--- a/stack/services/src/main/java/org/apache/usergrid/services/ServiceManagerFactory.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/ServiceManagerFactory.java
@@ -23,6 +23,8 @@ import java.util.UUID;
 
 import com.google.inject.Injector;
 import org.apache.usergrid.locking.Lock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -35,6 +37,7 @@ import org.apache.usergrid.persistence.EntityManagerFactory;
 
 
 public class ServiceManagerFactory implements ApplicationContextAware {
+    private static final Logger logger = LoggerFactory.getLogger( ServiceManagerFactory.class );
 
     private ApplicationContext applicationContext;
 
@@ -59,6 +62,15 @@ public class ServiceManagerFactory implements ApplicationContextAware {
 
 
     public ServiceManager getServiceManager( UUID applicationId ) {
+
+        // additional logging to help debug https://issues.apache.org/jira/browse/USERGRID-1291
+        if ( emf == null ) {
+            logger.error("EntityManagerFactory is null");
+        }
+        if ( qmf == null ) {
+            logger.error("QueueManagerFactory is null");
+        }
+
         EntityManager em = null;
         if ( emf != null ) {
             em = emf.getEntityManager( applicationId );


### PR DESCRIPTION
Changes related to management app / startup logic

1) Lock Manager setup now happens in the EntityManagerFactory and is invoked as part  of the normal /database/setup process.

2) CpEntityManagerFactory now checks for the existence of the management app and will retry if it cannot be found, unless Usergrid has not yet been bootstrapped. It will log the root cause exception and a track trace. Max retries and interval are configurable.

3) CpEntityManagerFactory now keeps a "cache" of the latest fetched Management App object. EntityManager cache will update the cached Management App object whenever it is successfully fetched.

4) CpEntityManagerFactory's cache of EntityManagers will not cache bad EntityManagers, i.e. those that cannot fetch their own applications, or the application's name is null. 

5) EntityManager cache size configurable via a new property ''entity.manager.cache.size"

6) Additional logging for when EntityManager, EntityManagerFactory, QueueManager or QueueManagerFactory is null.

https://issues.apache.org/jira/browse/USERGRID-1283