### PR TITLE
Allow .NET Integration Tests to be run against any usergrid installation

### DIFF
--- a/sdks/dotnet/Usergrid.Sdk.IntegrationTests/BaseTest.cs
+++ b/sdks/dotnet/Usergrid.Sdk.IntegrationTests/BaseTest.cs
@@ -32,7 +32,24 @@ namespace Usergrid.Sdk.IntegrationTests
 	            _config = config;
 	    }
 
-	    protected string Organization
+        /// <summary>
+        /// The URI of the Usergrid API, which defaults to api.usergrid.com if none is specified, just like the Client object does
+        /// </summary>
+        protected string ApiUri
+        {
+            get
+            {
+                var apiUri = GetAppSetting("apiUri");
+                if (String.IsNullOrWhiteSpace(apiUri))
+                {
+                    apiUri = "http://api.usergrid.com";
+                }
+
+                return apiUri;
+            }
+        }
+
+        protected string Organization
 		{
 			get{ return GetAppSetting("organization");}
 		}
@@ -84,12 +101,12 @@ namespace Usergrid.Sdk.IntegrationTests
 
         private string GetAppSetting(string key)
         {
-            return _config == null ? ConfigurationManager.AppSettings[key] : _config.AppSettings.Settings[key].Value;
+            return _config == null ? ConfigurationManager.AppSettings[key] : _config.AppSettings.Settings[key]?.Value;
         }
 
         protected IClient InitializeClientAndLogin(AuthType authType)
         {
-            var client = new Client(Organization, Application);
+            var client = new Client(Organization, Application, ApiUri);
             if (authType == AuthType.Application || authType == AuthType.Organization)
                 client.Login(ClientId, ClientSecret, authType);
             else if (authType == AuthType.User)

--- a/sdks/dotnet/Usergrid.Sdk.IntegrationTests/EntityPagingTests.cs
+++ b/sdks/dotnet/Usergrid.Sdk.IntegrationTests/EntityPagingTests.cs
@@ -31,7 +31,7 @@ namespace Usergrid.Sdk.IntegrationTests
 		[Test]
 		public void ShouldDoPaging()
 		{
-			var client = new Client(Organization, Application);
+			var client = new Client(Organization, Application, ApiUri);
 			client.Login(ClientId, ClientSecret, AuthType.Organization);
 
 			for (var i=0; i<20; i++) 

--- a/sdks/dotnet/Usergrid.Sdk.IntegrationTests/GroupTests.cs
+++ b/sdks/dotnet/Usergrid.Sdk.IntegrationTests/GroupTests.cs
@@ -30,7 +30,7 @@ namespace Usergrid.Sdk.IntegrationTests
         [Test]
         public void ShouldManageGroupLifecycle()
         {
-            var client = new Client(Organization, Application);
+            var client = new Client(Organization, Application, ApiUri);
             client.Login(ClientId, ClientSecret, AuthType.Organization);
 
             var group = client.GetGroup<MyUsergridGroup>("group1");
@@ -68,7 +68,7 @@ namespace Usergrid.Sdk.IntegrationTests
         [Test]
         public void ShouldManageUsersInGroup()
         {
-            var client = new Client(Organization, Application);
+            var client = new Client(Organization, Application, ApiUri);
             client.Login(ClientId, ClientSecret, AuthType.Organization);
 
             var user = SetupUsergridUser(client, new MyUsergridUser {UserName = "user1", Password = "user1", Email = "user1@gmail.com", City = "city1"});

--- a/sdks/dotnet/Usergrid.Sdk.IntegrationTests/LoginTests.cs
+++ b/sdks/dotnet/Usergrid.Sdk.IntegrationTests/LoginTests.cs
@@ -24,14 +24,14 @@ namespace Usergrid.Sdk.IntegrationTests
         [Test]
         public void ShouldLoginSuccessfullyWithClientCredentials()
         {
-            var client = new Client(Organization, Application);
+            var client = new Client(Organization, Application, ApiUri);
             client.Login(ClientId, ClientSecret, AuthType.Organization);
         }
 
 		[Test]
 		public void ShouldThrowWithInvalidOrganizationCredentials()
 		{
-			var client = new Client (Organization, Application);
+			var client = new Client (Organization, Application, ApiUri);
 
 			try
 			{
@@ -48,14 +48,14 @@ namespace Usergrid.Sdk.IntegrationTests
 		[Test]
 		public void ShouldLoginSuccessfullyWithApplicationCredentials()
 		{
-			var client = new Client(Organization, Application);
+			var client = new Client(Organization, Application, ApiUri);
 			client.Login(ApplicationId, ApplicationSecret, AuthType.Application);
 		}
 
 		[Test]
 		public void ShouldThrowWithInvalidApplicationCredentials()
 		{
-			var client = new Client (Organization, Application);
+			var client = new Client (Organization, Application, ApiUri);
 
 			try
 			{
@@ -72,14 +72,14 @@ namespace Usergrid.Sdk.IntegrationTests
 		[Test]
 		public void ShouldLoginSuccessfullyWithUserCredentials()
 		{
-			var client = new Client(Organization, Application);
+			var client = new Client(Organization, Application, ApiUri);
 			client.Login(UserId, UserSecret, AuthType.User);
 		}
 
         [Test]
         public void ShouldThrowWithInvalidUserCredentials()
         {
-            var client = new Client(Organization, Application);
+            var client = new Client(Organization, Application, ApiUri);
 
             try
             {

--- a/sdks/dotnet/Usergrid.Sdk.IntegrationTests/Usergrid.Sdk.IntegrationTests.dll.config
+++ b/sdks/dotnet/Usergrid.Sdk.IntegrationTests/Usergrid.Sdk.IntegrationTests.dll.config
@@ -18,6 +18,7 @@
 
 <configuration>
 	<appSettings>
+                <add key="apiUri" value="BASE_URI_OF_USERGRID_API" />
 		<add key="organization" value="ORGANIZATION_NAME" />
 		<add key="application" value="APPLICATION_NAME" />
 		<add key="clientId" value="CLIENT_ID" />


### PR DESCRIPTION
* Fixes https://issues.apache.org/jira/browse/USERGRID-1306
* Add a new apiUri configuration to the settings files that allow for running integration tests against something aside from http://api.usergrid.com
* If nothing is specified for this config or if it is missing, the default behavior of using http://api.usergrid.com is enforced