### PR TITLE
Add Feature Flags - enable ability to deploy Usergrid without Elasticsearch.

### DIFF
--- a/stack/config/src/main/resources/usergrid-default.properties
+++ b/stack/config/src/main/resources/usergrid-default.properties
@@ -49,6 +49,17 @@
 usergrid.persistence=CP
 
 
+###################  Usergrid Feature Implementation  ####################
+#
+# Set the features that should be enabled.  This will optionally inject certain dependencies.
+#
+# Valid values: all or kvm
+#
+# all - all features available including graph and query
+# graph - only graph and key-value map features available ( no query and no Elasticsearch required )
+#
+usergrid.features.enabled=all
+
 
 
 ###########################  Cassandra (Datastore)  ###########################
@@ -64,7 +75,7 @@ cassandra.version=2.1
 
 # Set the Cassandra cluster name that this instance of Usergrid should use.
 #
-cassandra.cluster=Test Cluster
+cassandra.cluster=CassandraClientCluster
 
 # Set a comma-separated list of one or more Cassandra hosts (host:port) that Usergrid will connect to.
 # If no port is provided, the default Cassandra port of 9160 will be used.

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
@@ -290,8 +290,11 @@ public class CpEntityManager implements EntityManager {
     public <A extends Entity> A create( String entityType, Class<A> entityClass, Map<String, Object> properties )
             throws Exception {
 
-        if ( ( entityType != null ) && ( entityType.startsWith( TYPE_ENTITY ) || entityType
-                .startsWith( "entities" ) ) ) {
+        if ( ( entityType != null ) &&
+            ( entityType.startsWith( TYPE_ENTITY ) || entityType.startsWith( "entities" )
+                // safeguard against creating entities with type keyvaluemaps since we have specific Usergrid
+                // keyvaluemap implementation
+                || entityType.startsWith( "keyvaluemaps" ) || entityType.startsWith( "keyvaluemap" )) ) {
             throw new IllegalArgumentException( "Invalid entity type" );
         }
         A e = null;

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpManagerCache.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpManagerCache.java
@@ -16,6 +16,7 @@
 package org.apache.usergrid.corepersistence;
 
 
+import com.google.inject.Injector;
 import org.apache.usergrid.corepersistence.index.IndexLocationStrategyFactory;
 import org.apache.usergrid.persistence.collection.EntityCollectionManager;
 import org.apache.usergrid.persistence.collection.EntityCollectionManagerFactory;
@@ -31,6 +32,7 @@ import org.apache.usergrid.persistence.map.MapManagerFactory;
 import org.apache.usergrid.persistence.map.MapScope;
 
 import com.google.inject.Inject;
+import org.apache.usergrid.system.UsergridFeatures;
 
 
 /**
@@ -40,30 +42,35 @@ import com.google.inject.Inject;
 public class CpManagerCache implements ManagerCache {
 
     private final EntityCollectionManagerFactory ecmf;
-    private final EntityIndexFactory eif;
+    private EntityIndexFactory eif = null;
     private final GraphManagerFactory gmf;
     private final MapManagerFactory mmf;
-    private final IndexLocationStrategyFactory indexLocationStrategyFactory;
-    private final IndexProducer indexProducer;
+    private IndexLocationStrategyFactory indexLocationStrategyFactory;
+    private final Injector injector;
 
     // TODO: consider making these cache sizes and timeouts configurable
 
 
     @Inject
     public CpManagerCache( final EntityCollectionManagerFactory ecmf,
-                           final EntityIndexFactory eif,
                            final GraphManagerFactory gmf,
                            final MapManagerFactory mmf,
-                           final IndexLocationStrategyFactory indexLocationStrategyFactory,
-                           final IndexProducer indexProducer
+                           final Injector injector
     ) {
 
+
         this.ecmf = ecmf;
-        this.eif = eif;
+        if(UsergridFeatures.isQueryFeatureEnabled()) {
+
+            this.eif = injector.getInstance(EntityIndexFactory.class);
+            this.indexLocationStrategyFactory = injector.getInstance(IndexLocationStrategyFactory.class);
+
+
+        }
+
         this.gmf = gmf;
         this.mmf = mmf;
-        this.indexLocationStrategyFactory = indexLocationStrategyFactory;
-        this.indexProducer = indexProducer;
+        this.injector = injector;
     }
 
 
@@ -91,11 +98,6 @@ public class CpManagerCache implements ManagerCache {
     @Override
     public MapManager getMapManager( MapScope mapScope ) {
         return mmf.createMapManager( mapScope );
-    }
-
-    @Override
-    public IndexProducer getIndexProducer() {
-        return indexProducer;
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpSetup.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpSetup.java
@@ -17,6 +17,7 @@
 package org.apache.usergrid.corepersistence;
 
 
+import org.apache.usergrid.system.UsergridFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,6 @@ public class CpSetup implements Setup {
 
     private static final Logger logger = LoggerFactory.getLogger( CpSetup.class );
 
-
     private final Injector injector;
 
 
@@ -77,8 +77,13 @@ public class CpSetup implements Setup {
     @Override
     public void initSchema() throws Exception {
 
-        // Initialize the management app index in Elasticsearch
-        this.emf.initializeManagementIndex();
+        if(UsergridFeatures.isQueryFeatureEnabled()) {
+
+            // Initialize the management app index in Elasticsearch
+            this.emf.initializeManagementIndex();
+
+        }
+
 
         // Create the schema (including keyspace) in Cassandra
         setupSchema();
@@ -125,8 +130,10 @@ public class CpSetup implements Setup {
         cass.createColumnFamilies( getApplicationKeyspace(),
             getCfDefs( ApplicationCF.class, getApplicationKeyspace() ) );
 
-        cass.createColumnFamilies( getApplicationKeyspace(),
-            getCfDefs( QueuesCF.class, getApplicationKeyspace() ) );
+        if( UsergridFeatures.isQueryFeatureEnabled() || UsergridFeatures.isGraphFeatureEnabled() ) {
+            cass.createColumnFamilies(getApplicationKeyspace(),
+                getCfDefs(QueuesCF.class, getApplicationKeyspace()));
+        }
 
         logger.info( "Keyspace and legacy column families initialized" );
     }

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/ManagerCache.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/ManagerCache.java
@@ -67,12 +67,6 @@ public interface ManagerCache {
     MapManager getMapManager(MapScope mapScope);
 
     /**
-     * gets index producer
-     * @return
-     */
-    IndexProducer getIndexProducer();
-
-    /**
      * invalidate the cache
      */
     void invalidate();

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/EventServiceFig.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/EventServiceFig.java
@@ -29,7 +29,7 @@ import org.safehaus.guicyfig.Key;
  * Application id cache fig
  */
 @FigSingleton
-public interface IndexProcessorFig extends GuicyFig {
+public interface EventServiceFig extends GuicyFig {
 
 
     String FAILURE_REJECTED_RETRY_WAIT_TIME = "elasticsearch.rejected_retry_wait";

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ReIndexServiceImpl.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/ReIndexServiceImpl.java
@@ -78,7 +78,7 @@ public class ReIndexServiceImpl implements ReIndexService {
     private final AllApplicationsObservable allApplicationsObservable;
     private final IndexLocationStrategyFactory indexLocationStrategyFactory;
     private final AllEntityIdsObservable allEntityIdsObservable;
-    private final IndexProcessorFig indexProcessorFig;
+    private final EventServiceFig eventServiceFig;
     private final MapManager mapManager;
     private final MapManagerFactory mapManagerFactory;
     private final AsyncEventService indexService;
@@ -92,14 +92,14 @@ public class ReIndexServiceImpl implements ReIndexService {
                                final AllEntityIdsObservable allEntityIdsObservable,
                                final MapManagerFactory mapManagerFactory,
                                final AllApplicationsObservable allApplicationsObservable,
-                               final IndexProcessorFig indexProcessorFig,
+                               final EventServiceFig eventServiceFig,
                                final CollectionSettingsFactory collectionSettingsFactory,
                                final AsyncEventService indexService ) {
         this.entityIndexFactory = entityIndexFactory;
         this.indexLocationStrategyFactory = indexLocationStrategyFactory;
         this.allEntityIdsObservable = allEntityIdsObservable;
         this.allApplicationsObservable = allApplicationsObservable;
-        this.indexProcessorFig = indexProcessorFig;
+        this.eventServiceFig = eventServiceFig;
         this.indexService = indexService;
         this.collectionSettingsFactory = collectionSettingsFactory;
         this.mapManagerFactory = mapManagerFactory;
@@ -164,14 +164,14 @@ public class ReIndexServiceImpl implements ReIndexService {
         Observable<List<EdgeScope>> runningReIndex = allEntityIdsObservable.getEdgesToEntities( applicationScopes,
             reIndexRequestBuilder.getCollectionName(), cursorSeek.getSeekValue() )
 
-            .buffer( indexProcessorFig.getReindexBufferSize())
+            .buffer( eventServiceFig.getReindexBufferSize())
             .flatMap( edgeScopes -> Observable.just(edgeScopes)
                 .doOnNext(edges -> {
 
                     logger.info("Sending batch of {} to be indexed.", edges.size());
                     indexService.indexBatch(edges, modifiedSince);
                 })
-                .subscribeOn( Schedulers.io() ), indexProcessorFig.getReindexConcurrencyFactor());
+                .subscribeOn( Schedulers.io() ), eventServiceFig.getReindexConcurrencyFactor());
 
 
         // start our sampler and state persistence

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/PipelineModule.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/PipelineModule.java
@@ -25,6 +25,8 @@ import org.apache.usergrid.corepersistence.pipeline.read.FilterFactory;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import org.apache.usergrid.corepersistence.pipeline.read.SearchFilterFactory;
+import org.apache.usergrid.system.UsergridFeatures;
 
 
 /**
@@ -35,9 +37,17 @@ public class PipelineModule extends AbstractModule {
     @Override
     protected void configure() {
 
-            //Use Guice to create the builder since we don't really need to do anything
+        //Use Guice to create the builder since we don't really need to do anything
         //other than DI when creating the filters
         install( new FactoryModuleBuilder().build( FilterFactory.class ) );
+
+        if( UsergridFeatures.isQueryFeatureEnabled() ) {
+
+            // only inject search filters that use Elasticsearch if the UG feature is enabled
+            install( new FactoryModuleBuilder().build( SearchFilterFactory.class ) );
+
+        }
+
 
         install( new FactoryModuleBuilder().build( PipelineBuilderFactory.class ) );
     }

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/CandidateBuilder.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/CandidateBuilder.java
@@ -23,6 +23,7 @@ package org.apache.usergrid.corepersistence.pipeline.builder;
 import org.apache.usergrid.corepersistence.pipeline.read.FilterFactory;
 import org.apache.usergrid.corepersistence.pipeline.Pipeline;
 import org.apache.usergrid.corepersistence.pipeline.read.FilterResult;
+import org.apache.usergrid.corepersistence.pipeline.read.SearchFilterFactory;
 import org.apache.usergrid.corepersistence.pipeline.read.search.Candidate;
 import org.apache.usergrid.persistence.model.entity.Entity;
 import org.apache.usergrid.persistence.model.entity.Id;
@@ -31,14 +32,17 @@ import org.apache.usergrid.persistence.model.entity.Id;
 public class CandidateBuilder {
 
 
+    private final SearchFilterFactory searchFilterFactory;
     private final Pipeline<FilterResult<Candidate>> pipeline;
     private final FilterFactory filterFactory;
 
 
     public CandidateBuilder( final Pipeline<FilterResult<Candidate>> pipeline,
-                             final FilterFactory filterFactory ) {
+                             final FilterFactory filterFactory,
+                             final SearchFilterFactory searchFilterFactory ) {
         this.pipeline = pipeline;
         this.filterFactory = filterFactory;
+        this.searchFilterFactory = searchFilterFactory;
     }
 
 
@@ -50,7 +54,7 @@ public class CandidateBuilder {
 
         final Pipeline<FilterResult<Id>> newFilter = pipeline.withFilter( filterFactory.candidateResultsIdVerifyFilter() );
 
-        return new IdBuilder( newFilter, filterFactory );
+        return new IdBuilder( newFilter, filterFactory, searchFilterFactory );
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/IdBuilder.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/IdBuilder.java
@@ -26,6 +26,7 @@ import org.apache.usergrid.corepersistence.pipeline.PipelineOperation;
 import org.apache.usergrid.corepersistence.pipeline.read.FilterFactory;
 import org.apache.usergrid.corepersistence.pipeline.read.FilterResult;
 import org.apache.usergrid.corepersistence.pipeline.read.ResultsPage;
+import org.apache.usergrid.corepersistence.pipeline.read.SearchFilterFactory;
 import org.apache.usergrid.corepersistence.pipeline.read.collect.ConnectionRefFilter;
 import org.apache.usergrid.corepersistence.pipeline.read.collect.ConnectionRefResumeFilter;
 import org.apache.usergrid.corepersistence.pipeline.read.collect.IdResumeFilter;
@@ -42,15 +43,24 @@ import rx.Observable;
  */
 public class IdBuilder {
 
-
+    private final SearchFilterFactory searchFilterFactory;
     private final FilterFactory filterFactory;
     private final Pipeline<FilterResult<Id>> pipeline;
 
 
+    public IdBuilder( final Pipeline<FilterResult<Id>> pipeline, final FilterFactory filterFactory,
+                      final SearchFilterFactory searchFilterFactory  ) {
+        this.pipeline = pipeline;
+        this.filterFactory = filterFactory;
+        this.searchFilterFactory = searchFilterFactory;
+    }
+
     public IdBuilder( final Pipeline<FilterResult<Id>> pipeline, final FilterFactory filterFactory ) {
         this.pipeline = pipeline;
         this.filterFactory = filterFactory;
+        this.searchFilterFactory = null;
     }
+
 
 
     /**
@@ -74,7 +84,7 @@ public class IdBuilder {
     public IdBuilder traverseReverseConnection( final String connectionName, final Optional<String> entityType ) {
         final PipelineOperation<FilterResult<Id>, FilterResult<Id>> filter;
         filter = filterFactory.readGraphReverseConnectionFilter( connectionName );
-        return new IdBuilder( pipeline.withFilter(filter ), filterFactory );
+        return new IdBuilder( pipeline.withFilter(filter ), filterFactory, searchFilterFactory );
     }
 
 
@@ -87,7 +97,7 @@ public class IdBuilder {
         final Pipeline<FilterResult<Id>> newFilter =
             pipeline.withFilter( filterFactory.readGraphCollectionFilter( collectionName ) );
 
-        return new IdBuilder( newFilter, filterFactory );
+        return new IdBuilder( newFilter, filterFactory, searchFilterFactory );
     }
 
 
@@ -108,7 +118,7 @@ public class IdBuilder {
         }
 
 
-        return new IdBuilder( pipeline.withFilter(filter ), filterFactory );
+        return new IdBuilder( pipeline.withFilter(filter ), filterFactory, searchFilterFactory );
     }
 
 
@@ -121,10 +131,10 @@ public class IdBuilder {
      */
     public CandidateBuilder searchCollection( final String collectionName, final String ql, final String entityType  ) {
 
-        final Pipeline<FilterResult<Candidate>> newFilter = pipeline.withFilter( filterFactory.searchCollectionFilter(
+        final Pipeline<FilterResult<Candidate>> newFilter = pipeline.withFilter( searchFilterFactory.searchCollectionFilter(
             ql, collectionName, entityType ) );
 
-        return new CandidateBuilder( newFilter, filterFactory );
+        return new CandidateBuilder( newFilter, filterFactory, searchFilterFactory );
     }
 
 
@@ -138,10 +148,10 @@ public class IdBuilder {
     public CandidateBuilder searchConnection( final String connectionName, final String ql ,  final Optional<String> entityType) {
 
 
-        final Pipeline<FilterResult<Candidate>> newFilter = pipeline.withFilter( filterFactory.searchConnectionFilter(
+        final Pipeline<FilterResult<Candidate>> newFilter = pipeline.withFilter( searchFilterFactory.searchConnectionFilter(
             ql, connectionName, entityType ) );
 
-        return new CandidateBuilder( newFilter, filterFactory );
+        return new CandidateBuilder( newFilter, filterFactory, searchFilterFactory );
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/IdBuilder.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/IdBuilder.java
@@ -55,12 +55,6 @@ public class IdBuilder {
         this.searchFilterFactory = searchFilterFactory;
     }
 
-    public IdBuilder( final Pipeline<FilterResult<Id>> pipeline, final FilterFactory filterFactory ) {
-        this.pipeline = pipeline;
-        this.filterFactory = filterFactory;
-        this.searchFilterFactory = null;
-    }
-
 
 
     /**

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/PipelineBuilder.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/PipelineBuilder.java
@@ -106,7 +106,7 @@ public class PipelineBuilder {
     public IdBuilder fromId(final Id entityId){
         Pipeline<FilterResult<Id>> pipeline =  new Pipeline( applicationScope, this.cursor,limit ).withFilter(  filterFactory.getEntityIdFilter( entityId ) );
 
-        return new IdBuilder( pipeline, filterFactory );
+        return new IdBuilder( pipeline, filterFactory, searchFilterFactory );
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/PipelineBuilder.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/builder/PipelineBuilder.java
@@ -20,9 +20,11 @@
 package org.apache.usergrid.corepersistence.pipeline.builder;
 
 
+import com.google.inject.Injector;
 import org.apache.usergrid.corepersistence.pipeline.read.FilterFactory;
 import org.apache.usergrid.corepersistence.pipeline.Pipeline;
 import org.apache.usergrid.corepersistence.pipeline.read.FilterResult;
+import org.apache.usergrid.corepersistence.pipeline.read.SearchFilterFactory;
 import org.apache.usergrid.persistence.core.scope.ApplicationScope;
 import org.apache.usergrid.persistence.model.entity.Id;
 
@@ -30,6 +32,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import org.apache.usergrid.system.UsergridFeatures;
 
 
 /**
@@ -38,12 +41,12 @@ import com.google.inject.assistedinject.Assisted;
  */
 public class PipelineBuilder {
 
-
-
     private final ApplicationScope applicationScope;
     private Optional<String> cursor = Optional.absent();
     private int limit = 10;
     private final FilterFactory filterFactory;
+    private SearchFilterFactory searchFilterFactory = null;
+    private final Injector injector;
 
 
     /**
@@ -51,9 +54,19 @@ public class PipelineBuilder {
      * @param filterFactory
      */
     @Inject
-    public PipelineBuilder( final FilterFactory filterFactory, @Assisted final ApplicationScope applicationScope ) {
+    public PipelineBuilder( final FilterFactory filterFactory, @Assisted final ApplicationScope applicationScope,
+                            final Injector injector ) {
         this.filterFactory = filterFactory;
         this.applicationScope = applicationScope;
+        this.injector = injector;
+
+        if(UsergridFeatures.isQueryFeatureEnabled()) {
+
+            this.searchFilterFactory = injector.getInstance(SearchFilterFactory.class);
+
+        }
+
+
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/FilterFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/FilterFactory.java
@@ -88,29 +88,6 @@ public interface FilterFactory {
      */
     ReadGraphConnectionByIdFilter readGraphConnectionByIdFilter( final String connectionName, final Id targetId );
 
-    /**
-     * Generate a new instance of the command with the specified parameters
-     *
-     * @param query The query to use when querying the entities in the collection
-     * @param collectionName The collection name to use when querying
-     */
-    SearchCollectionFilter searchCollectionFilter( @Assisted( "query" ) final String query,
-                                                   @Assisted( "collectionName" ) final String collectionName,
-                                                   @Assisted( "entityType" ) final String entityType );
-
-
-    /**
-     * Generate a new instance of the command with the specified parameters
-     *
-     * @param query The query to use when querying the entities in the connection
-     * @param connectionName The type of connection to query
-     * @param connectedEntityType The type of entity in the connection.  Leave absent to query all entity types
-     */
-    SearchConnectionFilter searchConnectionFilter( @Assisted( "query" ) final String query,
-                                                   @Assisted( "connectionName" ) final String connectionName,
-                                                   @Assisted( "connectedEntityType" )
-                                                   final Optional<String> connectedEntityType );
-
 
     /**
      * Generate a new instance of the command with the specified parameters

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/SearchFilterFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/SearchFilterFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.usergrid.corepersistence.pipeline.read;
+
+import com.google.common.base.Optional;
+import com.google.inject.assistedinject.Assisted;
+import org.apache.usergrid.corepersistence.pipeline.read.search.SearchCollectionFilter;
+import org.apache.usergrid.corepersistence.pipeline.read.search.SearchConnectionFilter;
+
+/**
+ * Created by russo on 9/2/16.
+ */
+public interface SearchFilterFactory {
+
+    /**
+     * Generate a new instance of the command with the specified parameters
+     *
+     * @param query The query to use when querying the entities in the collection
+     * @param collectionName The collection name to use when querying
+     */
+    SearchCollectionFilter searchCollectionFilter(@Assisted( "query" ) final String query,
+                                                  @Assisted( "collectionName" ) final String collectionName,
+                                                  @Assisted( "entityType" ) final String entityType );
+
+
+    /**
+     * Generate a new instance of the command with the specified parameters
+     *
+     * @param query The query to use when querying the entities in the connection
+     * @param connectionName The type of connection to query
+     * @param connectedEntityType The type of entity in the connection.  Leave absent to query all entity types
+     */
+    SearchConnectionFilter searchConnectionFilter(@Assisted( "query" ) final String query,
+                                                  @Assisted( "connectionName" ) final String connectionName,
+                                                  @Assisted( "connectedEntityType" )
+                                                  final Optional<String> connectedEntityType );
+}

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateEntityFilter.java
@@ -22,6 +22,7 @@ package org.apache.usergrid.corepersistence.pipeline.read.search;
 
 import java.util.*;
 
+import com.google.inject.Injector;
 import org.apache.usergrid.corepersistence.index.IndexLocationStrategyFactory;
 import org.apache.usergrid.persistence.index.*;
 import org.apache.usergrid.persistence.index.impl.IndexProducer;
@@ -30,6 +31,7 @@ import org.apache.usergrid.persistence.model.field.DoubleField;
 import org.apache.usergrid.persistence.model.field.EntityObjectField;
 import org.apache.usergrid.persistence.model.field.Field;
 import org.apache.usergrid.persistence.model.field.value.EntityObject;
+import org.apache.usergrid.system.UsergridFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,21 +61,28 @@ import rx.Observable;
 public class CandidateEntityFilter extends AbstractFilter<FilterResult<Candidate>, FilterResult<Entity>> {
 
     private final EntityCollectionManagerFactory entityCollectionManagerFactory;
-    private final EntityIndexFactory entityIndexFactory;
-    private final IndexLocationStrategyFactory indexLocationStrategyFactory;
-    private final IndexProducer indexProducer;
+    private EntityIndexFactory entityIndexFactory = null;
+    private IndexLocationStrategyFactory indexLocationStrategyFactory;
+    private IndexProducer indexProducer = null;
+    private final Injector injector;
 
 
     @Inject
-    public CandidateEntityFilter( final EntityCollectionManagerFactory entityCollectionManagerFactory,
-                                  final EntityIndexFactory entityIndexFactory,
-                                  final IndexLocationStrategyFactory indexLocationStrategyFactory,
-                                  final IndexProducer indexProducer
-                                  ) {
+    public CandidateEntityFilter(final EntityCollectionManagerFactory entityCollectionManagerFactory,
+                                 final Injector injector ) {
+
         this.entityCollectionManagerFactory = entityCollectionManagerFactory;
-        this.entityIndexFactory = entityIndexFactory;
-        this.indexLocationStrategyFactory = indexLocationStrategyFactory;
-        this.indexProducer = indexProducer;
+        this.injector = injector;
+
+
+        if(UsergridFeatures.isQueryFeatureEnabled()) {
+
+            this.entityIndexFactory = this.injector.getInstance(EntityIndexFactory.class);
+            this.indexProducer = this.injector.getInstance(IndexProducer.class);
+            this.indexLocationStrategyFactory = this.injector.getInstance(IndexLocationStrategyFactory.class);
+
+
+        }
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateIdFilter.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/pipeline/read/search/CandidateIdFilter.java
@@ -24,9 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.google.inject.Injector;
 import org.apache.usergrid.corepersistence.index.IndexLocationStrategyFactory;
 import org.apache.usergrid.persistence.index.*;
 import org.apache.usergrid.persistence.index.impl.IndexProducer;
+import org.apache.usergrid.system.UsergridFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,20 +54,26 @@ import rx.Observable;
 public class CandidateIdFilter extends AbstractFilter<FilterResult<Candidate>, FilterResult<Id>> {
 
     private final EntityCollectionManagerFactory entityCollectionManagerFactory;
-    private final EntityIndexFactory entityIndexFactory;
-    private final IndexLocationStrategyFactory indexLocationStrategyFactory;
-    private final IndexProducer indexProducer;
+    private EntityIndexFactory entityIndexFactory = null;
+    private IndexLocationStrategyFactory indexLocationStrategyFactory;
+    private IndexProducer indexProducer = null;
+    private final Injector injector;
 
 
     @Inject
     public CandidateIdFilter( final EntityCollectionManagerFactory entityCollectionManagerFactory,
-                              final EntityIndexFactory entityIndexFactory,
-                              final IndexLocationStrategyFactory indexLocationStrategyFactory,
-                              final IndexProducer indexProducer) {
+                              final Injector injector ) {
+
+        this.injector = injector;
         this.entityCollectionManagerFactory = entityCollectionManagerFactory;
-        this.entityIndexFactory = entityIndexFactory;
-        this.indexLocationStrategyFactory = indexLocationStrategyFactory;
-        this.indexProducer = indexProducer;
+
+        if (UsergridFeatures.isQueryFeatureEnabled()) {
+
+            this.entityIndexFactory = this.injector.getInstance(EntityIndexFactory.class);
+            this.indexProducer = this.injector.getInstance(IndexProducer.class);
+            this.indexLocationStrategyFactory = this.injector.getInstance(IndexLocationStrategyFactory.class);
+
+        }
     }
 
 

--- a/stack/core/src/main/java/org/apache/usergrid/persistence/Query.java
+++ b/stack/core/src/main/java/org/apache/usergrid/persistence/Query.java
@@ -31,6 +31,7 @@ import org.apache.usergrid.persistence.index.query.tree.Operand;
 import org.apache.usergrid.persistence.index.utils.ClassUtils;
 import org.apache.usergrid.persistence.index.utils.ListUtils;
 import org.apache.usergrid.persistence.index.utils.MapUtils;
+import org.apache.usergrid.system.UsergridFeatures;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -41,8 +42,6 @@ import java.util.Map.Entry;
 
 
 public class Query {
-
-
 
     public enum Level {
         IDS, REFS, CORE_PROPERTIES, ALL_PROPERTIES, LINKED_PROPERTIES
@@ -199,6 +198,12 @@ public class Query {
         List<CounterFilterPredicate> counterFilters = null;
 
         String ql = QueryUtils.queryStrFrom( params );
+        final boolean queryFeatureEnabled = UsergridFeatures.isQueryFeatureEnabled();
+
+        if( StringUtils.isNotEmpty(ql) && (!queryFeatureEnabled && !ql.equalsIgnoreCase("select *")) ){
+            throw new UnsupportedOperationException("Query features are not enabled.");
+        }
+
         String type = ListUtils.first( params.get( "type" ) );
         Boolean reversed = ListUtils.firstBoolean( params.get( "reversed" ) );
         String connection = ListUtils.first( params.get( "connectionType" ) );

--- a/stack/core/src/main/java/org/apache/usergrid/system/UsergridFeatures.java
+++ b/stack/core/src/main/java/org/apache/usergrid/system/UsergridFeatures.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.usergrid.system;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UsergridFeatures {
+
+    public static final String USERGRID_FEATURES_ENABLED_PROP = "usergrid.features.enabled";
+
+    public enum Feature {
+
+        ALL, GRAPH, KVM
+
+    }
+
+
+    public static Collection<Feature> getFeaturesEnabled(){
+
+        List<Feature> features = new ArrayList<>();
+
+        String featureString = System.getProperty(USERGRID_FEATURES_ENABLED_PROP, "all");
+
+        String[] splitFeatures = featureString.split(",");
+        for(String feature : splitFeatures){
+
+            features.add(Feature.valueOf(feature.toUpperCase()));
+
+        }
+
+        return features;
+
+    }
+
+    public static boolean isGraphFeatureEnabled(){
+
+        return getFeaturesEnabled().contains(Feature.ALL) || getFeaturesEnabled().contains(Feature.GRAPH);
+
+    }
+
+    public static boolean isQueryFeatureEnabled(){
+
+        return getFeaturesEnabled().contains(Feature.ALL);
+
+    }
+
+    public static boolean isKvmFeatureEnabled(){
+
+        return  getFeaturesEnabled().contains(Feature.KVM);
+
+    }
+}

--- a/stack/core/src/main/java/org/apache/usergrid/system/UsergridFeatures.java
+++ b/stack/core/src/main/java/org/apache/usergrid/system/UsergridFeatures.java
@@ -63,7 +63,7 @@ public class UsergridFeatures {
 
     public static boolean isKvmFeatureEnabled(){
 
-        return  getFeaturesEnabled().contains(Feature.KVM);
+        return true;
 
     }
 }

--- a/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/AsyncEventServiceImplTest.java
+++ b/stack/core/src/test/java/org/apache/usergrid/corepersistence/index/AsyncEventServiceImplTest.java
@@ -21,6 +21,7 @@ package org.apache.usergrid.corepersistence.index;
 
 
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.usergrid.corepersistence.TestIndexModule;
 import org.apache.usergrid.corepersistence.asyncevents.AsyncEventService;
@@ -56,7 +57,7 @@ public class AsyncEventServiceImplTest extends AsyncIndexServiceTest {
     public QueueManagerFactory queueManagerFactory;
 
     @Inject
-    public IndexProcessorFig indexProcessorFig;
+    public EventServiceFig eventServiceFig;
 
     @Inject
     public QueueFig queueFig;
@@ -84,9 +85,14 @@ public class AsyncEventServiceImplTest extends AsyncIndexServiceTest {
     @Inject
     public EntityIndexFactory entityIndexFactory;
 
+    @Inject
+    public Injector injector;
+
     @Override
     protected AsyncEventService getAsyncEventService() {
-        return  new AsyncEventServiceImpl( queueManagerFactory, indexProcessorFig, indexProducer, metricsFactory,  entityCollectionManagerFactory, indexLocationStrategyFactory, entityIndexFactory, eventBuilder, mapManagerFactory, queueFig,  rxTaskScheduler );
+        return  new AsyncEventServiceImpl( queueManagerFactory, eventServiceFig, metricsFactory,
+            entityCollectionManagerFactory, entityIndexFactory, eventBuilder,
+            mapManagerFactory, queueFig,  rxTaskScheduler, injector );
     }
 
 

--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/datastax/impl/DataStaxClusterImpl.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/datastax/impl/DataStaxClusterImpl.java
@@ -185,7 +185,8 @@ public class DataStaxClusterImpl implements DataStaxCluster {
             .withPoolingOptions(poolingOptions)
             .withQueryOptions(queryOptions)
             .withSocketOptions(socketOptions)
-            .withProtocolVersion(getProtocolVersion(cassandraFig.getVersion()));
+            .withProtocolVersion(getProtocolVersion(cassandraFig.getVersion()))
+            .withTimestampGenerator(new AtomicMonotonicTimestampGenerator());
 
         // only add auth credentials if they were provided
         if ( !cassandraFig.getUsername().isEmpty() && !cassandraFig.getPassword().isEmpty() ){

--- a/stack/corepersistence/map/src/main/java/org/apache/usergrid/persistence/map/impl/MapSerializationImpl.java
+++ b/stack/corepersistence/map/src/main/java/org/apache/usergrid/persistence/map/impl/MapSerializationImpl.java
@@ -67,7 +67,7 @@ public class MapSerializationImpl implements MapSerialization {
     private static final Map<String, DataType.Name> MAP_KEYS_COLUMNS =
         new HashMap<String, DataType.Name>() {{
             put( "key", DataType.Name.BLOB );
-            put( "column1", DataType.Name.BLOB );
+            put( "column1", DataType.Name.TEXT );
             put( "value", DataType.Name.BLOB ); }};
     private static final Map<String, String> MAP_KEYS_CLUSTERING_ORDER =
         new HashMap<String, String>(){{ put( "column1", "ASC" ); }};
@@ -169,7 +169,7 @@ public class MapSerializationImpl implements MapSerialization {
             mapKey = QueryBuilder.insertInto(MAP_KEYS_TABLE)
                 .using(timeToLive)
                 .value("key", getMapKeyPartitionKey(scope, bucket))
-                .value("column1", DataType.text().serialize(key, ProtocolVersion.NEWEST_SUPPORTED))
+                .value("column1", key)
                 .value("value", DataType.cboolean().serialize(true, ProtocolVersion.NEWEST_SUPPORTED));
         }else{
 
@@ -183,7 +183,7 @@ public class MapSerializationImpl implements MapSerialization {
 
             mapKey = QueryBuilder.insertInto(MAP_KEYS_TABLE)
                 .value("key", getMapKeyPartitionKey(scope, bucket))
-                .value("column1", DataType.text().serialize(key, ProtocolVersion.NEWEST_SUPPORTED))
+                .value("column1", key)
                 .value("value", DataType.cboolean().serialize(true, ProtocolVersion.NEWEST_SUPPORTED));
 
         }
@@ -223,7 +223,7 @@ public class MapSerializationImpl implements MapSerialization {
         Statement mapKey;
         mapKey = QueryBuilder.insertInto(MAP_KEYS_TABLE)
             .value("key", getMapKeyPartitionKey(scope, bucket))
-            .value("column1", DataType.text().serialize(key, ProtocolVersion.NEWEST_SUPPORTED))
+            .value("column1", key)
             .value("value", DataType.serializeValue(null, ProtocolVersion.NEWEST_SUPPORTED));
 
         session.execute(mapKey);
@@ -260,7 +260,7 @@ public class MapSerializationImpl implements MapSerialization {
         Statement mapKey;
         mapKey = QueryBuilder.insertInto(MAP_KEYS_TABLE)
             .value("key", getMapKeyPartitionKey(scope, bucket))
-            .value("column1", DataType.text().serialize(key, ProtocolVersion.NEWEST_SUPPORTED))
+            .value("column1", key)
             .value("value", DataType.cboolean().serialize(true, ProtocolVersion.NEWEST_SUPPORTED));
 
         session.execute(mapKey);
@@ -357,7 +357,7 @@ public class MapSerializationImpl implements MapSerialization {
         while( resultIterator.hasNext() && size < limit){
 
             size++;
-            keys.add((String)DataType.text().deserialize(resultIterator.next().getBytes("column1"), ProtocolVersion.NEWEST_SUPPORTED));
+            keys.add(resultIterator.next().getString("column1"));
 
         }
 

--- a/stack/corepersistence/pom.xml
+++ b/stack/corepersistence/pom.xml
@@ -80,11 +80,11 @@ limitations under the License.
         <commons.collections.version>3.2.1</commons.collections.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>3.1</commons.lang.version>
-        <datastax.version>2.1.9</datastax.version>
+        <datastax.version>2.1.10.3</datastax.version>
         <elasticsearch.version>1.4.4</elasticsearch.version>
         <fasterxml-uuid.version>3.1.3</fasterxml-uuid.version>
         <guava.version>18.0</guava.version>
-        <guice.version>4.0-beta5</guice.version>
+        <guice.version>4.0</guice.version>
         <guicyfig.version>3.2</guicyfig.version>
         <hystrix.version>1.4.0</hystrix.version>
         <jackson-2-version>2.4.1</jackson-2-version>

--- a/stack/corepersistence/queryindex/src/main/java/org/apache/usergrid/persistence/index/guice/IndexModule.java
+++ b/stack/corepersistence/queryindex/src/main/java/org/apache/usergrid/persistence/index/guice/IndexModule.java
@@ -44,9 +44,7 @@ public abstract class IndexModule extends AbstractModule {
 
         // install our configuration
         install(new GuicyFigModule(IndexFig.class));
-
         install(new MapModule());
-        install(new QueueModule());
 
         bind( EntityIndexFactory.class ).to( EsEntityIndexFactoryImpl.class );
         bind(IndexCache.class).to(EsIndexCacheImpl.class);

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -102,7 +102,7 @@
         <aws.version>1.10.20</aws.version>
         <cassandra-version>1.2.18</cassandra-version>
         <guava.version>18.0</guava.version>
-        <guice.version>4.0-beta5</guice.version>
+        <guice.version>4.0</guice.version>
         <hector-om-version>3.0-03</hector-om-version>
         <hector-version>1.1-4</hector-version>
         <hector-test-version>1.1-4</hector-test-version>

--- a/stack/query-validator/src/test/java/org/apache/usergrid/query/validator/users/UserQueryIT.java
+++ b/stack/query-validator/src/test/java/org/apache/usergrid/query/validator/users/UserQueryIT.java
@@ -17,10 +17,8 @@
 package org.apache.usergrid.query.validator.users;
 
 import net.jcip.annotations.NotThreadSafe;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.apache.usergrid.system.UsergridFeatures;
+import org.junit.*;
 import org.apache.usergrid.persistence.Entity;
 import org.apache.usergrid.query.validator.AbstractQueryIT;
 import org.apache.usergrid.query.validator.QueryRequest;
@@ -29,6 +27,10 @@ import org.apache.usergrid.query.validator.QueryResultsMatcher;
 import org.apache.usergrid.utils.StringUtils;
 
 import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 
 /**
@@ -41,6 +43,15 @@ public class UserQueryIT extends AbstractQueryIT {
     public static void setDatas() throws InterruptedException{
         createInitializationDatas("user");
     }
+
+    @Before
+    public void checkFeatures(){
+
+        assumeTrue(UsergridFeatures.isQueryFeatureEnabled());
+
+    }
+
+
 
     @Test
     public void sexEqualAndNameEqual() {

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/AbstractContextResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/AbstractContextResource.java
@@ -125,6 +125,9 @@ public abstract class AbstractContextResource {
             logger.trace("getSubResource: {}", t.getCanonicalName());
         }
         T subResource = resourceContext.getResource(t);
+        if(!subResource.isEnabled()){
+            return null;
+        }
         subResource.setParent(this);
         return subResource;
     }
@@ -274,5 +277,11 @@ public abstract class AbstractContextResource {
             return true;
         }
         return false;
+    }
+
+    public boolean isEnabled(){
+
+        return true;
+
     }
 }

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/JobServiceBoostrap.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/JobServiceBoostrap.java
@@ -19,6 +19,7 @@ package org.apache.usergrid.rest;
 import org.apache.usergrid.batch.service.JobSchedulerService;
 import org.apache.usergrid.persistence.EntityManager;
 import org.apache.usergrid.services.notifications.QueueListener;
+import org.apache.usergrid.system.UsergridFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +62,7 @@ public class JobServiceBoostrap implements
     @Override
     public void onApplicationEvent( ContextRefreshedEvent event ) {
         String start = properties.getProperty( START_SCHEDULER_PROP, "true" );
-        if ( Boolean.parseBoolean( start ) ) {
+        if ( Boolean.parseBoolean( start ) && (UsergridFeatures.isGraphFeatureEnabled() || UsergridFeatures.isQueryFeatureEnabled()) ) {
             logger.info( "Starting Scheduler Service..." );
             jobScheduler.startAsync();
             jobScheduler.awaitRunning();

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/RootResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/RootResource.java
@@ -34,6 +34,7 @@ import org.apache.usergrid.rest.applications.ApplicationResource;
 import org.apache.usergrid.rest.exceptions.NoOpException;
 import org.apache.usergrid.rest.organizations.OrganizationResource;
 import org.apache.usergrid.rest.security.annotations.RequireSystemAccess;
+import org.apache.usergrid.system.UsergridFeatures;
 import org.apache.usergrid.system.UsergridSystemMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -197,8 +198,10 @@ public class RootResource extends AbstractContextResource implements MetricProce
         // Core Persistence Collections module status
         node.put( "cassandraStatus", emf.getEntityStoreHealth().toString() );
 
-        // Core Persistence Query Index module status for Management App Index
-        node.put( "managementAppIndexStatus", emf.getIndexHealth().toString() );
+        if(UsergridFeatures.isQueryFeatureEnabled()) {
+            // Core Persistence Query Index module status for Management App Index
+            node.put("managementAppIndexStatus", emf.getIndexHealth().toString());
+        }
 
 
         dumpMetrics(node);

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ApplicationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ApplicationResource.java
@@ -148,8 +148,8 @@ public class ApplicationResource extends CollectionResource {
         return getEventsResource( ui );
     }
 
-    //@RequireApplicationAccess
-    @Path("maps")
+    @RequireApplicationAccess
+    @Path("keyvaluemaps")
     public KvmResource getKvmResource(@Context UriInfo ui ) throws Exception {
         return getSubResource( KvmResource.class );
     }

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ApplicationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ApplicationResource.java
@@ -41,6 +41,7 @@ import org.apache.usergrid.rest.AbstractContextResource;
 import org.apache.usergrid.rest.ApiResponse;
 import org.apache.usergrid.rest.applications.assets.AssetsResource;
 import org.apache.usergrid.rest.applications.events.EventsResource;
+import org.apache.usergrid.rest.applications.kvm.KvmResource;
 import org.apache.usergrid.rest.applications.queues.QueueResource;
 import org.apache.usergrid.rest.applications.users.UsersResource;
 import org.apache.usergrid.rest.exceptions.AuthErrorInfo;
@@ -145,6 +146,12 @@ public class ApplicationResource extends CollectionResource {
     @Path("event")
     public EventsResource getEventResource( @Context UriInfo ui ) throws Exception {
         return getEventsResource( ui );
+    }
+
+    //@RequireApplicationAccess
+    @Path("maps")
+    public KvmResource getKvmResource(@Context UriInfo ui ) throws Exception {
+        return getSubResource( KvmResource.class );
     }
 
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ServiceResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/ServiceResource.java
@@ -81,7 +81,7 @@ public class ServiceResource extends AbstractContextResource {
     @Autowired
     private AwsSdkS3BinaryStore awsSdkS3BinaryStore;
 
-    protected ServiceManager services;
+    public ServiceManager services;
 
     List<ServiceParameter> serviceParameters = null;
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/applications/kvm/KvmResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/applications/kvm/KvmResource.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.usergrid.rest.applications.kvm;
+
+import com.google.inject.Injector;
+import org.apache.commons.lang.StringUtils;
+import org.apache.usergrid.persistence.map.MapKeyResults;
+import org.apache.usergrid.persistence.map.MapManager;
+import org.apache.usergrid.persistence.map.MapManagerFactory;
+import org.apache.usergrid.persistence.map.MapScope;
+import org.apache.usergrid.persistence.map.impl.MapScopeImpl;
+import org.apache.usergrid.rest.AbstractContextResource;
+import org.apache.usergrid.rest.ApiResponse;
+import org.apache.usergrid.rest.applications.ServiceResource;
+import org.apache.usergrid.services.ServiceManager;
+import org.apache.usergrid.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import rx.Observable;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+import java.util.*;
+
+@Component("org.apache.usergrid.rest.applications.kvm.KvmResource")
+@Scope("prototype")
+@Produces({ MediaType.APPLICATION_JSON, "application/javascript", "application/x-javascript", "text/ecmascript",
+    "application/ecmascript", "text/jscript"
+})
+public class KvmResource extends AbstractContextResource {
+
+    private static final Logger logger = LoggerFactory.getLogger( KvmResource.class );
+
+
+    private final int PAGE_SIZE_MAX = 1000;
+    private final int PAGE_SIZE_DEFAULT = 10;
+    private final int BATCH_SIZE_MAX = 10;
+
+    ServiceManager services = null;
+
+    @Autowired
+    private Injector injector;
+
+    public KvmResource(){
+        if(logger.isTraceEnabled()) {
+            logger.trace("kvm.KvmResource");
+        }
+    }
+
+    @Override
+    public void setParent( AbstractContextResource parent ) {
+        super.setParent( parent );
+        if ( parent instanceof ServiceResource ) {
+            services = ( ( ServiceResource ) parent ).services;
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse createMap( @Context UriInfo ui,
+                                  Map<String, Object> json ) {
+
+        if( json.keySet().size() < 1 ){
+            throw new IllegalArgumentException("New map must be specified");
+        }
+        if( json.keySet().size() > 1 ){
+            throw new IllegalArgumentException("Only 1 map can be created at a time.");
+        }
+
+        final String mapName = json.keySet().iterator().next();
+        final Object meta = json.get(mapName);
+        if( !(meta instanceof Map) ){
+            throw new IllegalArgumentException("New map details must be provided as a JSON object.");
+        }
+
+        if(StringUtils.isEmpty(mapName)){
+            throw new IllegalArgumentException("Property mapName is required.");
+        }
+
+        final String appMap = services.getApplicationId().toString();
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), appMap);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+        final Map<String, Object> mapDetails = new HashMap<String, Object>(){{
+
+            put("active", true);
+            put("modified", System.currentTimeMillis() );
+            put("details", meta);
+
+        }};
+
+        mapManager.putString(mapName, JsonUtils.mapToJsonString(mapDetails));
+
+        // This used for response format
+        final Map<String, Object> map = new HashMap<>(2);
+        map.put(mapName, mapDetails);
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "post" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("maps", Collections.singletonList(map));
+
+        return response;
+
+    }
+
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse getMaps( @Context UriInfo ui,
+                                @QueryParam("limit") int limit,
+                                @QueryParam("cursor") String cursor) {
+
+        limit = validateLimit(limit);
+
+        final String appMap = services.getApplicationId().toString();
+
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), appMap);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+        MapKeyResults mapKeyResults = mapManager.getKeys(cursor, limit );
+
+        List<Map<String, Object>> results = new ArrayList<>();
+
+        Observable.from(mapKeyResults.getKeys()).flatMap(key -> {
+            return Observable.just(new HashMap<String, Object>() {{
+                put(key, JsonUtils.parse(mapManager.getString(key)));
+            }});
+
+        }).doOnNext(entry -> results.add(entry)).toBlocking().lastOrDefault(null);
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "get" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("maps", results);
+
+        if( StringUtils.isNotEmpty(mapKeyResults.getCursor())){
+            response.setProperty("cursor", mapKeyResults.getCursor());
+        }
+
+        return response;
+
+    }
+
+    @GET
+    @Path("{mapName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse getSingleMap( @Context UriInfo ui,
+                                @QueryParam("limit") int limit,
+                                @QueryParam("cursor") String cursor,
+                                @PathParam("mapName") String mapName ) {
+
+        limit = validateLimit(limit);
+
+        final String appMap = services.getApplicationId().toString();
+
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), appMap);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+
+        Map<String, Object> map = new HashMap<>();
+        map.put(mapName, JsonUtils.parse(mapManager.getString(mapName)));
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "get" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("maps", Collections.singletonList(map));
+
+        return response;
+
+    }
+
+
+    @POST
+    @Path("{mapName}/entries")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse createEntries( @Context UriInfo ui,
+                                      List<Map<String,Object>> json,
+                                      @PathParam("mapName") String mapName ) {
+
+        if ( json.size() > BATCH_SIZE_MAX ){
+            throw new IllegalArgumentException("Batch size "+json.size()+" is more than max size of "+BATCH_SIZE_MAX);
+        }
+
+        if(StringUtils.isEmpty(mapName)){
+            throw new IllegalArgumentException("Property mapName is required.");
+        }
+
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), mapName);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+        //TODO maybe RX flatmap this or parallel stream
+        json.forEach( item -> {
+
+            String key = item.keySet().iterator().next();
+            Object value = item.get(key);
+
+            mapManager.putString(key, value.toString());
+
+
+        });
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "post" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("mapName", mapName);
+        response.setProperty("entries", json);
+
+        return response;
+
+    }
+
+    @GET
+    @Path("{mapName}/keys")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse getKeys( @Context UriInfo ui,
+                                @QueryParam("limit") int limit,
+                                @QueryParam("cursor") String cursor,
+                                @PathParam("mapName") String mapName ) {
+
+
+        if(StringUtils.isEmpty(mapName)){
+            throw new IllegalArgumentException("Property mapName is required.");
+        }
+
+        limit = validateLimit(limit);
+
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), mapName);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+        MapKeyResults mapKeyResults = mapManager.getKeys(cursor, limit );
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "get" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("keys", mapKeyResults.getKeys());
+
+        if( StringUtils.isNotEmpty(mapKeyResults.getCursor())){
+            response.setProperty("cursor", mapKeyResults.getCursor());
+        }
+
+        return response;
+
+    }
+
+    @GET
+    @Path("{mapName}/entries")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse getEntries( @Context UriInfo ui,
+                                   @QueryParam("limit") int limit,
+                                   @QueryParam("cursor") String cursor,
+                                   @PathParam("mapName") String mapName ) {
+
+        if(StringUtils.isEmpty(mapName)){
+            throw new IllegalArgumentException("Property mapName is required.");
+        }
+
+        limit = validateLimit(limit);
+
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), mapName);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+        MapKeyResults mapKeyResults = mapManager.getKeys(cursor, limit );
+
+        List<Map<String, String>> results = new ArrayList<>();
+        Observable.from(mapKeyResults.getKeys()).flatMap(key ->{
+            return Observable.just(new HashMap<String, String>(){{put(key, mapManager.getString(key));}});
+
+        }).doOnNext(entry -> results.add(entry)).toBlocking().lastOrDefault(null);
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "get" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("entries", results);
+
+        if( StringUtils.isNotEmpty(mapKeyResults.getCursor())){
+            response.setProperty("cursor", mapKeyResults.getCursor());
+        }
+
+        return response;
+
+    }
+
+    @GET
+    @Path("{mapName}/entries/{keyName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ApiResponse getEntry( @Context UriInfo ui,
+                                   @PathParam("mapName") String mapName,
+                                   @PathParam("keyName") String keyName ) {
+
+
+        final MapScope mapScope = new MapScopeImpl(services.getApplication().asId(), mapName);
+        final MapManagerFactory mmf = injector.getInstance(MapManagerFactory.class);
+        final MapManager mapManager = mmf.createMapManager(mapScope);
+
+
+        List<Map<String, String>> results = new ArrayList<>();
+        results.add(new HashMap<String, String>(){{put(keyName, mapManager.getString(keyName));}});
+
+
+        ApiResponse response = createApiResponse();
+        response.setAction( "get" );
+        response.setApplication( services.getApplication() );
+        response.setParams( ui.getQueryParameters() );
+        response.setProperty("entries", results);
+
+        return response;
+
+    }
+
+
+    private int validateLimit(final int limit){
+
+        return limit > 0 && limit < PAGE_SIZE_MAX ? limit : PAGE_SIZE_DEFAULT;
+
+    }
+
+
+}

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/UnsupportedOperationExceptionMapper.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/UnsupportedOperationExceptionMapper.java
@@ -20,6 +20,7 @@ package org.apache.usergrid.rest.exceptions;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 
@@ -30,6 +31,6 @@ public class UnsupportedOperationExceptionMapper extends AbstractExceptionMapper
 
     @Override
     public Response toResponse( UnsupportedOperationException e ) {
-        return toResponse( INTERNAL_SERVER_ERROR, e );
+        return toResponse( BAD_REQUEST, e );
     }
 }

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/system/IndexResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/system/IndexResource.java
@@ -35,6 +35,7 @@ import org.apache.usergrid.rest.AbstractContextResource;
 import org.apache.usergrid.rest.ApiResponse;
 import org.apache.usergrid.rest.RootResource;
 import org.apache.usergrid.rest.security.annotations.RequireSystemAccess;
+import org.apache.usergrid.system.UsergridFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
@@ -357,5 +358,11 @@ public class IndexResource extends AbstractContextResource {
         response.setSuccess();
 
         return response;
+    }
+
+    @Override
+    public boolean isEnabled(){
+
+        return UsergridFeatures.isQueryFeatureEnabled();
     }
 }

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/system/SystemResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/system/SystemResource.java
@@ -94,7 +94,6 @@ public class SystemResource extends AbstractContextResource {
         return getSubResource( MigrateResource.class );
     }
 
-
     @Path( "index" )
     public IndexResource index() { return getSubResource( IndexResource.class ); }
 

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/test/resource/AbstractRestIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/test/resource/AbstractRestIT.java
@@ -30,7 +30,6 @@ import org.apache.usergrid.rest.test.resource.model.Token;
 import org.apache.usergrid.rest.test.resource.state.ClientContext;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.jackson.JacksonFeature;
-import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.external.ExternalTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainer;

--- a/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
@@ -70,6 +70,7 @@ import org.apache.usergrid.security.tokens.TokenInfo;
 import org.apache.usergrid.security.tokens.TokenService;
 import org.apache.usergrid.security.tokens.exceptions.TokenException;
 import org.apache.usergrid.services.*;
+import org.apache.usergrid.system.UsergridFeatures;
 import org.apache.usergrid.utils.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,7 +167,7 @@ public class ManagementServiceImpl implements ManagementService {
 
     protected CacheFactory cacheFactory;
 
-    protected AggregationServiceFactory aggregationServiceFactory;
+    protected AggregationServiceFactory aggregationServiceFactory = null;
 
     protected ApplicationService service;
 
@@ -211,7 +212,13 @@ public class ManagementServiceImpl implements ManagementService {
         // Use the injector to get our guice dependencies
         this.lockManager = injector.getInstance(LockManager.class);
         this.cacheFactory = injector.getInstance( CacheFactory.class );
-        this.aggregationServiceFactory = injector.getInstance(AggregationServiceFactory.class);
+
+        if(UsergridFeatures.isQueryFeatureEnabled()) {
+
+            this.aggregationServiceFactory = injector.getInstance(AggregationServiceFactory.class);
+
+
+        }
         this.service = injector.getInstance(ApplicationService.class);
         this.localShiroCache = injector.getInstance(LocalShiroCache.class);
 


### PR DESCRIPTION
This PR is introducing a new property `usergrid.features.enabled` such that someone could configure usergrid to use graph only without query/index, removing the requirement for Elasticsearch.

It also adds a new `maps` resource with simple key-value map storage with all the standard user/client authentication benefits that Usergrid offers.

https://issues.apache.org/jira/browse/USERGRID-1272