### PR TITLE
Configurable ElasticSearch indexing implementation

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CoreModule.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CoreModule.java
@@ -44,6 +44,7 @@ import org.apache.usergrid.persistence.graph.serialization.impl.migration.GraphN
 import org.apache.usergrid.persistence.index.guice.IndexModule;
 import org.safehaus.guicyfig.GuicyFigModule;
 
+import java.util.Properties;
 import java.util.concurrent.ThreadPoolExecutor;
 
 
@@ -52,6 +53,11 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 public class CoreModule extends AbstractModule {
 
+    private final Properties properties;
+
+    public CoreModule( Properties properties ) {
+        this.properties = properties;
+    }
 
     @Override
     protected void configure() {
@@ -79,7 +85,8 @@ public class CoreModule extends AbstractModule {
                 bind( new TypeLiteral<MigrationDataProvider<GraphNode>>() {} ).to( AllNodesInGraphImpl.class );
             }
         } );
-        install( new IndexModule() {
+
+        install( new IndexModule( properties ) {
             @Override
             public void configureMigrationProvider() {
                 bind( new TypeLiteral<MigrationDataProvider<ApplicationScope>>() {} )

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
@@ -3106,6 +3106,7 @@ public class CpEntityManager implements EntityManager {
             Entity refreshEntity = create("refresh", map);
             EntityIndex.IndexRefreshCommandInfo indexRefreshCommandInfo
                 = managerCache.getEntityIndex(applicationScope).refreshAsync().toBlocking().first();
+
             try {
                 for (int i = 0; i < 20; i++) {
                     if (searchCollection(
@@ -3118,7 +3119,7 @@ public class CpEntityManager implements EntityManager {
                         hasFinished = true;
                         break;
                     }
-                    Thread.sleep(100);
+                    Thread.sleep(500);
 
                     indexRefreshCommandInfo
                         = managerCache.getEntityIndex(applicationScope).refreshAsync().toBlocking().first();

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CpEntityManager.java
@@ -3108,7 +3108,7 @@ public class CpEntityManager implements EntityManager {
                 = managerCache.getEntityIndex(applicationScope).refreshAsync().toBlocking().first();
 
             try {
-                for (int i = 0; i < 20; i++) {
+                for (int i = 0; i < 40; i++) {
                     if (searchCollection(
                         new SimpleEntityRef(
                             org.apache.usergrid.persistence.entities.Application.ENTITY_TYPE, getApplicationId()),

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/GuiceFactory.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/GuiceFactory.java
@@ -148,7 +148,7 @@ public class GuiceFactory implements FactoryBean<Injector> {
             Module serviceModule =(Module)applicationContext.getBean("serviceModule");
             moduleList.add( serviceModule);
         }
-        moduleList.add(new CoreModule());
+        moduleList.add(new CoreModule( systemProperties ));
         moduleList.add(new PersistenceModule(applicationContext));
         //we have to inject a couple of spring beans into our Guice.  Wire it with PersistenceModule
         injector = Guice.createInjector( moduleList );

--- a/stack/core/src/test/java/org/apache/usergrid/corepersistence/TestCoreModule.java
+++ b/stack/core/src/test/java/org/apache/usergrid/corepersistence/TestCoreModule.java
@@ -20,6 +20,8 @@ package org.apache.usergrid.corepersistence;
 
 import org.apache.usergrid.persistence.core.guice.TestModule;
 
+import java.util.Properties;
+
 
 /**
  * Test guice module for our core guice configuration
@@ -29,6 +31,8 @@ public class TestCoreModule extends TestModule {
     @Override
     protected void configure() {
 
-        install( new CoreModule() );
+        Properties properties = new Properties();
+        properties.setProperty( "elasticsearch.queue_impl", "DISTRIBUTED" );
+        install( new CoreModule( properties ) );
     }
 }

--- a/stack/core/src/test/java/org/apache/usergrid/corepersistence/TestIndexModule.java
+++ b/stack/core/src/test/java/org/apache/usergrid/corepersistence/TestIndexModule.java
@@ -25,6 +25,8 @@ import org.apache.usergrid.persistence.PersistenceModule;
 import org.apache.usergrid.persistence.core.guice.TestModule;
 import org.apache.usergrid.setup.ConcurrentProcessSingleton;
 
+import java.util.Properties;
+
 
 public class TestIndexModule extends TestModule {
 
@@ -32,12 +34,14 @@ public class TestIndexModule extends TestModule {
     @Override
     protected void configure() {
 
-
         //TODO, refactor to guice to get rid of this
-        final ApplicationContext singleton = ConcurrentProcessSingleton.getInstance().getSpringResource().getAppContext();
+        final ApplicationContext singleton =
+            ConcurrentProcessSingleton.getInstance().getSpringResource().getAppContext();
 
         //this will break, we need to untagle this and move to guice in core completely
-        install( new CoreModule() );
+        Properties properties = new Properties();
+        properties.setProperty( "elasticsearch.queue_impl", "DISTRIBUTED" );
+        install( new CoreModule( properties ) );
         install( new PersistenceModule( singleton ) );
     }
 }

--- a/stack/core/src/test/resources/usergrid-custom-test.properties
+++ b/stack/core/src/test/resources/usergrid-custom-test.properties
@@ -28,7 +28,7 @@ elasticsearch.management_number_replicas=0
 elasticsearch.managment_index=usergrid_core_management
 #cassandra.keyspace.application=core_tests_schema
 elasticsearch.queue_impl.resolution=true
-elasticsearch.queue_impl=LOCAL
+elasticsearch.queue_impl=DISTRIBUTED
 
 elasticsearch.buffer_timeout=1
 

--- a/stack/core/src/test/resources/usergrid-custom-test.properties
+++ b/stack/core/src/test/resources/usergrid-custom-test.properties
@@ -28,6 +28,7 @@ elasticsearch.management_number_replicas=0
 elasticsearch.managment_index=usergrid_core_management
 #cassandra.keyspace.application=core_tests_schema
 elasticsearch.queue_impl.resolution=true
+elasticsearch.queue_impl=LOCAL
 
 elasticsearch.buffer_timeout=1
 

--- a/stack/corepersistence/queryindex/src/main/java/org/apache/usergrid/persistence/index/guice/IndexModule.java
+++ b/stack/corepersistence/queryindex/src/main/java/org/apache/usergrid/persistence/index/guice/IndexModule.java
@@ -35,8 +35,17 @@ import org.apache.usergrid.persistence.queue.guice.QueueModule;
 
 import org.safehaus.guicyfig.GuicyFigModule;
 
+import java.util.Properties;
+
 
 public abstract class IndexModule extends AbstractModule {
+
+    private final Properties properties;
+
+    public IndexModule( Properties properties ) {
+        this.properties = properties;
+    }
+
 
     @Override
     protected void configure() {
@@ -45,7 +54,7 @@ public abstract class IndexModule extends AbstractModule {
         install(new GuicyFigModule(IndexFig.class));
 
         install(new MapModule());
-        install(new QueueModule());
+        install(new QueueModule( properties.getProperty( "elasticsearch.queue_impl" ) ));
 
         bind( EntityIndexFactory.class ).to( EsEntityIndexFactoryImpl.class );
         bind(IndexCache.class).to(EsIndexCacheImpl.class);

--- a/stack/corepersistence/queryindex/src/test/java/org/apache/usergrid/persistence/index/guice/TestIndexModule.java
+++ b/stack/corepersistence/queryindex/src/test/java/org/apache/usergrid/persistence/index/guice/TestIndexModule.java
@@ -32,6 +32,8 @@ import com.google.inject.TypeLiteral;
 
 import rx.Observable;
 
+import java.util.Properties;
+
 
 public class TestIndexModule extends TestModule {
 
@@ -42,7 +44,11 @@ public class TestIndexModule extends TestModule {
         install( new CommonModule());
 
         // configure collections and our core astyanax framework
-        install( new IndexModule(){
+
+        Properties properties = new Properties();
+        properties.setProperty( "elasticsearch.queue_impl", "DISTRIBUTED" );
+
+        install( new IndexModule( properties ) {
             @Override
             public  void configureMigrationProvider(){
 

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueManager.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueManager.java
@@ -27,6 +27,15 @@ import java.util.List;
 public interface LegacyQueueManager {
 
     /**
+     * Different implementations
+     */
+    enum Implementation {
+        LOCAL,           // local in-memory queue
+        DISTRIBUTED,     // built-in Akka-based queue
+        DISTRIBUTED_SNS; // SNS queue
+    }
+
+    /**
      * Read messages from queue
      * @param limit
      * @param klass class to cast the return from

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/guice/QueueModule.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/guice/QueueModule.java
@@ -27,8 +27,6 @@ import org.apache.usergrid.persistence.queue.impl.QueueManagerFactoryImpl;
 import org.apache.usergrid.persistence.queue.impl.SNSQueueManagerImpl;
 import org.safehaus.guicyfig.GuicyFigModule;
 
-import java.util.Properties;
-
 
 /**
  * Simple module for wiring our collection api
@@ -37,16 +35,17 @@ public class QueueModule extends AbstractModule {
 
     private LegacyQueueManager.Implementation implementation;
 
+
     public QueueModule( String queueManagerType ) {
 
-        if ( "LOCAL".equals( queueManagerType ) ) {
-            this.implementation = LegacyQueueManager.Implementation.LOCAL;
-        }
-        else if ( "DISTRIBUTED_SNS".equals( queueManagerType ) ) {
+        if ( "DISTRIBUTED_SNS".equals( queueManagerType ) ) {
             this.implementation = LegacyQueueManager.Implementation.DISTRIBUTED_SNS;
         }
         else if ( "DISTRIBUTED".equals( queueManagerType ) ) {
             this.implementation = LegacyQueueManager.Implementation.DISTRIBUTED;
+        }
+        else {
+            this.implementation = LegacyQueueManager.Implementation.LOCAL;
         }
     }
 
@@ -61,7 +60,6 @@ public class QueueModule extends AbstractModule {
         switch (implementation) {
 
             case LOCAL:
-
                 install( new FactoryModuleBuilder().implement( LegacyQueueManager.class, LocalQueueManager.class )
                     .build( LegacyQueueManagerInternalFactory.class ) );
                 break;

--- a/stack/corepersistence/queue/src/test/java/org/apache/usergrid/persistence/queue/TestModule.java
+++ b/stack/corepersistence/queue/src/test/java/org/apache/usergrid/persistence/queue/TestModule.java
@@ -35,7 +35,7 @@ public class TestModule  extends AbstractModule {
 
         install( new CommonModule() );
         install( new ActorSystemModule() );
-        install( new QueueModule() );
+        install( new QueueModule( "DISTRIBUTED" ) );
 
     }
 

--- a/stack/rest/src/test/resources/usergrid-custom-test.properties
+++ b/stack/rest/src/test/resources/usergrid-custom-test.properties
@@ -66,3 +66,5 @@ usergrid.cluster.port=2555
 
 collection.uniquevalues.actors=300
 collection.uniquevalues.authoritative.region=us-east
+
+elasticsearch.queue_impl=DISTRIBUTED

--- a/stack/services/src/test/resources/usergrid-custom-test.properties
+++ b/stack/services/src/test/resources/usergrid-custom-test.properties
@@ -33,7 +33,7 @@ elasticsearch.managment_index=usergrid_services_management
 
 elasticsearch.buffer_timeout=1
 elasticsearch.queue_impl.resolution=true
-usergrid.use.default.queue=true
+elasticsearch.queue_impl=DISTRIBUTED
 
 
 # This property is required to be set and cannot be defaulted anywhere


### PR DESCRIPTION
Make it possible to configure either LOCAL, DISTRIBUTED or DISTRIBUTED_SNS queue; also: set Core tests to use DISTRIBUTED queue (i.e. Qakka).
