### PR TITLE
dead letter queue handling

### DIFF
--- a/stack/config/src/main/resources/usergrid-default.properties
+++ b/stack/config/src/main/resources/usergrid-default.properties
@@ -305,10 +305,15 @@ cassandra.lock.writecl=LOCAL_QUORUM
 #
 #elasticsearch.refresh_search_max=10
 
-# Set the amount of time to wait when Elasticsearch rejects a requests before
+# Set the amount of time to wait when indexing or utility queue rejects a request before
 # retrying.  This provides simple backpressure. (in milliseconds)
 #
-#elasticsearch.rejected_retry_wait
+#elasticsearch.rejected_retry_wait=1000
+
+# Set the amount of time to wait when indexing or utility dead letter queue rejects a request before
+# retrying.  This provides simple backpressure. (in milliseconds)
+#
+#elasticsearch.deadletter.rejected_retry_wait=2000
 
 
 
@@ -332,9 +337,21 @@ cassandra.lock.writecl=LOCAL_QUORUM
 #
 #usergrid.use.default.queue=false
 
-# The number of worker threads used to read index write requests from the queue.
+# The number of worker threads used to read index write requests from the indexing queue.
 #
 #elasticsearch.worker_count=8
+
+# The number of worker threads used to read index write requests from the utility queue.
+#
+#elasticsearch.worker_count_utility=2
+
+# The number of worker threads used to read dead letter messages from the indexing dead letter queue.
+#
+#elasticsearch.worker_count_deadletter=1
+
+# The number of worker threads used to read dead letter messages from the utility dead letter queue.
+#
+#elasticsearch.worker_count_utility_deadletter=1
 
 # Set the number of worker threads used for processing index write requests to
 # Elasticsearch from the buffer.
@@ -342,8 +359,7 @@ cassandra.lock.writecl=LOCAL_QUORUM
 #index.flush.workers=10
 
 # Set the implementation to use for queuing in Usergrid.
-# Valid values: TEST, LOCAL, SQS, SNS
-# NOTE: SQS and SNS equate to the same implementation of Amazon queue services.
+# Valid values: LOCAL, DISTRIBUTED, DISTRIBUTED_SNS
 #
 #elasticsearch.queue_impl=LOCAL
 

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/CoreModule.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/CoreModule.java
@@ -44,6 +44,7 @@ import org.apache.usergrid.persistence.core.scope.ApplicationScope;
 import org.apache.usergrid.persistence.graph.guice.GraphModule;
 import org.apache.usergrid.persistence.graph.serialization.impl.migration.GraphNode;
 import org.apache.usergrid.persistence.index.guice.IndexModule;
+import org.apache.usergrid.persistence.queue.LegacyQueueFig;
 import org.safehaus.guicyfig.GuicyFigModule;
 
 import java.util.Properties;

--- a/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/IndexProcessorFig.java
+++ b/stack/core/src/main/java/org/apache/usergrid/corepersistence/index/IndexProcessorFig.java
@@ -34,9 +34,15 @@ public interface IndexProcessorFig extends GuicyFig {
 
     String FAILURE_REJECTED_RETRY_WAIT_TIME = "elasticsearch.rejected_retry_wait";
 
+    String DLQ_FAILURE_REJECTED_RETRY_WAIT_TIME = "elasticsearch.deadletter.rejected_retry_wait";
+
     String ELASTICSEARCH_WORKER_COUNT = "elasticsearch.worker_count";
 
     String ELASTICSEARCH_WORKER_COUNT_UTILITY = "elasticsearch.worker_count_utility";
+
+    String ELASTICSEARCH_WORKER_COUNT_DEADLETTER = "elasticsearch.worker_count_deadletter";
+
+    String ELASTICSEARCH_WORKER_COUNT_UTILITY_DEADLETTER = "elasticsearch.worker_count_utility_deadletter";
 
     String EVENT_CONCURRENCY_FACTOR = "event.concurrency.factor";
 
@@ -50,12 +56,20 @@ public interface IndexProcessorFig extends GuicyFig {
 
 
     /**
-     * Set the amount of time to wait when Elasticsearch rejects a requests before
+     * Set the amount of time to wait when indexing or utility queue rejects a request before
      * retrying.  This provides simple back pressure. (in milliseconds)
      */
     @Default("1000")
     @Key(FAILURE_REJECTED_RETRY_WAIT_TIME)
     long getFailureRetryTime();
+
+    /**
+     * Set the amount of time to wait when indexing or utility dead letter queue rejects a request before
+     * retrying.  This provides simple back pressure. (in milliseconds)
+     */
+    @Default("2000")
+    @Key(DLQ_FAILURE_REJECTED_RETRY_WAIT_TIME)
+    long getDeadLetterFailureRetryTime();
 
 
     /**
@@ -89,6 +103,20 @@ public interface IndexProcessorFig extends GuicyFig {
     @Default("2")
     @Key(ELASTICSEARCH_WORKER_COUNT_UTILITY)
     int getWorkerCountUtility();
+
+    /**
+     * The number of worker threads used to read dead messages from the index dead letter queue and reload them into the index queue.
+     */
+    @Default("1")
+    @Key(ELASTICSEARCH_WORKER_COUNT_DEADLETTER)
+    int getWorkerCountDeadLetter();
+
+    /**
+     * The number of worker threads used to read dead messages from the utility dead letter queue and reload them into the utility queue.
+     */
+    @Default("1")
+    @Key(ELASTICSEARCH_WORKER_COUNT_UTILITY_DEADLETTER)
+    int getWorkerCountUtilityDeadLetter();
 
     /**
      * Set the implementation to use for queuing.

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueFig.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueFig.java
@@ -14,11 +14,14 @@ public interface LegacyQueueFig extends GuicyFig {
      * http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html*
      */
 
+    String USERGRID_CLUSTER_REGION_LIST = "usergrid.cluster.region.list";
+    String USERGRID_CLUSTER_REGION_LOCAL = "usergrid.cluster.region.local";
+
 
     /**
      * Primary region to use for Amazon queues.
      */
-    @Key( "usergrid.cluster.region.local" )
+    @Key( USERGRID_CLUSTER_REGION_LOCAL )
     @Default("us-east-1")
     String getPrimaryRegion();
 
@@ -34,7 +37,7 @@ public interface LegacyQueueFig extends GuicyFig {
      * Comma-separated list of one or more Amazon regions to use if multiregion
      * is set to true.
      */
-    @Key( "usergrid.cluster.region.list" )
+    @Key( USERGRID_CLUSTER_REGION_LIST )
     @Default("us-east-1")
     String getRegionList();
 

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueFig.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueFig.java
@@ -106,4 +106,7 @@ public interface LegacyQueueFig extends GuicyFig {
     @Default("false") // 30 seconds
     boolean getQuorumFallback();
 
+    @Key("usergrid.queue.map.message.timeout")
+    @Default("900000") // 15 minutes
+    int getMapMessageTimeout();
 }

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueManager.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueManager.java
@@ -20,6 +20,7 @@ package org.apache.usergrid.persistence.queue;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Set;
 
 /**ctor
  * Manages queues for usergrid.  Current implementation is sqs based.
@@ -66,6 +67,14 @@ public interface LegacyQueueManager {
      * @throws IOException
      */
     void sendMessages(List bodies) throws IOException;
+
+    /**
+     * send messages to queue
+     * @param queueMessages
+     * @throws IOException
+     * @return set of receipt handles for successfully sent messages
+     */
+    List<LegacyQueueMessage> sendQueueMessages(List<LegacyQueueMessage> queueMessages) throws IOException;
 
     /**
      * send a message to queue

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueScope.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LegacyQueueScope.java
@@ -40,4 +40,9 @@ public interface LegacyQueueScope {
      * Get the Usergrid region enum
      */
     RegionImplementation getRegionImplementation();
+
+    /**
+     * Is this for the dead letter queue?
+     */
+    boolean isDeadLetterQueue();
 }

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LocalQueueManager.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/LocalQueueManager.java
@@ -27,9 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -90,6 +88,22 @@ public class LocalQueueManager implements LegacyQueueManager {
                 throw new RuntimeException(ie);
             }
         }
+    }
+
+    @Override
+    public List<LegacyQueueMessage> sendQueueMessages(List<LegacyQueueMessage> queueMessages) throws IOException {
+        List<LegacyQueueMessage> successMessages = new ArrayList<>();
+        for(LegacyQueueMessage queueMessage : queueMessages){
+            String uuid = UUID.randomUUID().toString();
+            try {
+                LegacyQueueMessage msg = new LegacyQueueMessage(uuid, "handle_" + uuid, queueMessage.getBody(), "put type here");
+                queue.put(msg);
+                successMessages.add(queueMessage);
+            }catch (InterruptedException ie){
+                throw new RuntimeException(ie);
+            }
+        }
+        return successMessages;
     }
 
 

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/guice/QueueModule.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/guice/QueueModule.java
@@ -27,18 +27,22 @@ import org.apache.usergrid.persistence.queue.impl.QakkaQueueManager;
 import org.apache.usergrid.persistence.queue.impl.QueueManagerFactoryImpl;
 import org.apache.usergrid.persistence.queue.impl.SNSQueueManagerImpl;
 import org.safehaus.guicyfig.GuicyFigModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Simple module for wiring our collection api
  */
 public class QueueModule extends AbstractModule {
+    private static final Logger logger = LoggerFactory.getLogger( QueueModule.class );
 
     private LegacyQueueManager.Implementation implementation;
 
 
     public QueueModule( String queueManagerType ) {
 
+        logger.info("QueueManagerType={}", queueManagerType);
         if ( "DISTRIBUTED_SNS".equals( queueManagerType ) ) {
             this.implementation = LegacyQueueManager.Implementation.DISTRIBUTED_SNS;
         }

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/LegacyQueueScopeImpl.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/LegacyQueueScopeImpl.java
@@ -23,10 +23,18 @@ public class LegacyQueueScopeImpl implements LegacyQueueScope {
 
     private final String name;
     private final RegionImplementation regionImpl;
+    private final boolean isDeadLetterQueue;
 
     public LegacyQueueScopeImpl(final String name, final RegionImplementation regionImpl) {
         this.name = name;
         this.regionImpl = regionImpl;
+        this.isDeadLetterQueue = false;
+    }
+
+    public LegacyQueueScopeImpl(final String name, final RegionImplementation regionImpl, final boolean isDeadLetterQueue) {
+        this.name = name;
+        this.regionImpl = regionImpl;
+        this.isDeadLetterQueue = isDeadLetterQueue;
     }
 
     @Override
@@ -36,6 +44,9 @@ public class LegacyQueueScopeImpl implements LegacyQueueScope {
 
     @Override
     public RegionImplementation getRegionImplementation() {return regionImpl;}
+
+    @Override
+    public boolean isDeadLetterQueue() {return isDeadLetterQueue;}
 
     @Override
     public boolean equals( final Object o ) {
@@ -52,6 +63,13 @@ public class LegacyQueueScopeImpl implements LegacyQueueScope {
             return false;
         }
 
+        if ( regionImpl != queueScope.getRegionImplementation() ) {
+            return false;
+        }
+
+        if ( isDeadLetterQueue != queueScope.isDeadLetterQueue ) {
+            return false;
+        }
 
         return true;
     }
@@ -59,6 +77,11 @@ public class LegacyQueueScopeImpl implements LegacyQueueScope {
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        String deadLetter = "REGULAR";
+        if (isDeadLetterQueue) {
+            deadLetter = "DEADLETTER";
+        }
+        String hashString = name + "|" + regionImpl.name() + "|" + deadLetter;
+        return hashString.hashCode();
     }
 }

--- a/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/QakkaQueueManager.java
+++ b/stack/corepersistence/queue/src/main/java/org/apache/usergrid/persistence/queue/impl/QakkaQueueManager.java
@@ -195,6 +195,19 @@ public class QakkaQueueManager implements LegacyQueueManager {
 
 
     @Override
+    public List<LegacyQueueMessage> sendQueueMessages( List<LegacyQueueMessage> queueMessages ) throws IOException {
+
+        List<LegacyQueueMessage> successMessages = new ArrayList<>();
+        for ( LegacyQueueMessage queueMessage : queueMessages ) {
+            sendMessageToLocalRegion( (Serializable)queueMessage.getBody() );
+            successMessages.add(queueMessage);
+        }
+
+        return successMessages;
+    }
+
+
+    @Override
     public void deleteQueue() {
         queueManager.deleteQueue( scope.getName() );
     }

--- a/stack/services/src/main/java/org/apache/usergrid/services/AbstractCollectionService.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/AbstractCollectionService.java
@@ -19,6 +19,7 @@ package org.apache.usergrid.services;
 
 import java.util.*;
 
+import org.apache.usergrid.persistence.exceptions.DuplicateUniquePropertyExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -441,6 +442,14 @@ public class AbstractCollectionService extends AbstractService {
                 try {
                     item = em.createItemInCollection( context.getOwner(), context.getCollectionName(), getEntityType(),
                             p );
+                }
+                catch (DuplicateUniquePropertyExistsException e) {
+                    // this is not an error (caller tried to create entity with a duplicate unique value)
+                    logger.info("Entity [{}] unable to be created in collection [{}] due to [{} - {}]", p, context.getCollectionName(),
+                        e.getClass().getSimpleName(), e.getMessage());
+
+                    // would be nice if status for each batch entry was returned...
+                    continue;
                 }
                 catch ( Exception e ) {
 

--- a/stack/services/src/main/java/org/apache/usergrid/services/queues/ImportQueueManager.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/queues/ImportQueueManager.java
@@ -24,7 +24,9 @@ package org.apache.usergrid.services.queues;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.usergrid.persistence.queue.LegacyQueueManager;
 import org.apache.usergrid.persistence.queue.LegacyQueueMessage;
@@ -61,6 +63,12 @@ public class ImportQueueManager implements LegacyQueueManager {
     @Override
     public void sendMessages( final List bodies ) throws IOException {
 
+    }
+
+
+    @Override
+    public List<LegacyQueueMessage> sendQueueMessages(final List<LegacyQueueMessage> queueMessages ) throws IOException {
+        return new ArrayList<>();
     }
 
 


### PR DESCRIPTION
1. Add workers that move messages from dead letter queues back to the indexing and utility queues.
2. Change ERROR for DuplicateUniquePropertyExistsException to INFO. This happens when someone tries to create an entity with the same unique value as another entity, which is not an error that should be logged.
3. Add better logging when cluster region or region list has an invalid region.