### PR TITLE
Fixed shiro cache to ensure 1:1 mapping between token and principal

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/ManagementResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/ManagementResource.java
@@ -189,6 +189,9 @@ public class ManagementResource extends AbstractContextResource {
         final boolean ssoEnabled = Boolean.parseBoolean(properties.getProperty(USERGRID_EXTERNAL_SSO_ENABLED));
         long tokenTtl;
 
+        //@TODO - This code takes the access token from the principal in the cache instead of using the sesssion token.
+        //The token needs to be taken from the thread context instead to ensure that the correct token for the session is used
+      
         PrincipalIdentifier userPrincipal  = (PrincipalIdentifier) SecurityUtils.getSubject().getPrincipal();
         if ( userPrincipal != null && userPrincipal.getAccessTokenCredentials() != null ) {
             this.access_token = userPrincipal.getAccessTokenCredentials().getToken();


### PR DESCRIPTION
Before this, if a user had multiple sessions with different tokens,
only one Principal was stored in the cache, with the first token. Now
every user session has a principal mapped to it in the cache

https://issues.apache.org/jira/browse/USERGRID-1353?filter=-1