### PR TITLE
USERGRID-1348 : Fix failure for CollectionDeleteTest

### DIFF
--- a/stack/Jenkinsfile
+++ b/stack/Jenkinsfile
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 pipeline {
     agent { label 'ubuntu' }
 
@@ -24,7 +25,7 @@ pipeline {
     }
 
     options {
-          timeout(time: 30, unit: 'MINUTES')
+          timeout(time: 120, unit: 'MINUTES')
       }
 
 
@@ -70,7 +71,7 @@ pipeline {
             steps {
                 git 'https://github.com/apache/usergrid.git'
                 sh '''
-                    mvn clean install -DskipTests=true -f stack/pom.xml
+                    mvn clean install -f stack/pom.xml
                 '''
             }
         }
@@ -82,7 +83,7 @@ pipeline {
             junit 'stack/**/surefire-reports/*.xml'
             sh 'ps -ef | grep cassandra'
             sh 'ps -ef | grep elastic'
-            deleteDir() /* clean up our workspace */
+            deleteDir()  /*clean up our workspace */
         }
         success {
             echo 'Usergrid build and tests succeeded'
@@ -93,7 +94,3 @@ pipeline {
 
     }
 }
-
-
-
-


### PR DESCRIPTION
The test for CollectionDelete is failing on machines with more
processing power because the timestamp for the last to-be-deleted entry
and the next one ends up being the same. Added a sleep and also setup
non-boundary test scenarios and more logging.
Updated the Jenkins build to increase timeouts